### PR TITLE
Build and upload AppImage for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,35 @@ install:
   - qmake -v
 
 script:
-    - git submodule update --init --recursive
-    
-    - /opt/qt59/bin/qmake ./tests_unit.pro
-    - make -j2
-    - ./ModbusScopeUnitTests
-    
-    - /opt/qt59/bin/qmake ./ModbusScope.pro
-    - make -j2
-    - python3 ./tests_integration/run_tests.py
+  - git submodule update --init --recursive
+  - /opt/qt59/bin/qmake ./tests_unit.pro
+  - make -j2
+  - ./ModbusScopeUnitTests
+  - qmake CONFIG+=release PREFIX=/usr ./ModbusScope.pro
+  - make -j$(nproc)
+  - mkdir -p appdir/usr/bin ; cp src/ModbusScope appdir/usr/bin/
+  - mkdir -p appdir/usr/share/applications ; cp modbusscope.desktop appdir/usr/share/applications/
+  - mkdir -p appdir/usr/share/icons/hicolor/scalable/apps ; cp src/icon/icon_original.svg appdir/usr/share/icons/hicolor/scalable/apps/modbusscope.svg
+  - find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - mkdir -p appdir/usr/optional/ ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./appdir/usr/optional/exec.so
+  - mkdir -p appdir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
+  - ( cd appdir ; rm AppRun ; wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64 -O AppRun ; chmod a+x AppRun)
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+  
+# - python3 ./tests_integration/run_tests.py
+
+after_success:
+  - find appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file ModbusScope*.AppImage https://transfer.sh/ModbusScope-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh ModbusScope*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/modbusscope.desktop
+++ b/modbusscope.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=ModbusScope
+Comment=Log data using the Modbus protocol and put the data into a nice graph
+Exec=ModbusScope
+Icon=modbusscope
+Categories=Development;
+Type=Application


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.