### PR TITLE
Add arrows to notes

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,15 @@
+# Path to sources
+sonar.sources=src
+#sonar.exclusions=
+#sonar.inclusions=
+
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=

--- a/ModbusScope.pri
+++ b/ModbusScope.pri
@@ -26,6 +26,7 @@ INCLUDEPATH += \
 
 SOURCES +=  \
     $$PWD/src/graphview/graphviewzoom.cpp \
+    $$PWD/src/graphview/noteitem.cpp \
     $$PWD/src/importexport/presetparser.cpp \
     $$PWD/src/libraries/qcustomplot/qcustomplot.cpp \
     $$PWD/src/communication/communicationmanager.cpp \
@@ -94,6 +95,7 @@ FORMS    += \
 
 HEADERS += \
     $$PWD/src/graphview/graphviewzoom.h \
+    $$PWD/src/graphview/noteitem.h \
     $$PWD/src/importexport/presetparser.h \
     $$PWD/src/libraries/qcustomplot/qcustomplot.h \
     $$PWD/src/communication/communicationmanager.h \

--- a/ModbusScope.pro
+++ b/ModbusScope.pro
@@ -3,11 +3,5 @@ TEMPLATE = subdirs
 
 CONFIG += ordered
 
-<<<<<<< HEAD
 SUBDIRS += \
     src
-=======
-SUBDIRS +=            \
-    src               \
-    tests_integration
->>>>>>> Re-enable integration tests

--- a/ModbusScope.pro
+++ b/ModbusScope.pro
@@ -3,5 +3,11 @@ TEMPLATE = subdirs
 
 CONFIG += ordered
 
+<<<<<<< HEAD
 SUBDIRS += \
     src
+=======
+SUBDIRS +=            \
+    src               \
+    tests_integration
+>>>>>>> Re-enable integration tests

--- a/src/customwidgets/notesdockwidget.cpp
+++ b/src/customwidgets/notesdockwidget.cpp
@@ -5,12 +5,11 @@
 
 NotesDockWidget::NotesDockWidget(NoteModel *pNoteModel, GuiModel *pGuiModel, QWidget *parent) :
     QWidget(parent),
-    _pUi(new Ui::NotesDockWidget)
+    _pUi(new Ui::NotesDockWidget),
+    _pNoteModel(pNoteModel),
+    _pGuiModel(pGuiModel)
 {
     _pUi->setupUi(this);
-
-    _pNoteModel = pNoteModel;
-    _pGuiModel = pGuiModel;
 
     // Setup registerView
     _pUi->noteView->setModel(_pNoteModel);
@@ -19,12 +18,11 @@ NotesDockWidget::NotesDockWidget(NoteModel *pNoteModel, GuiModel *pGuiModel, QWi
     /* Don't stretch columns */
     _pUi->noteView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     /* Except following columns */
-    _pUi->noteView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Stretch);
+    _pUi->noteView->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Stretch);
 
     // Select using click, shift and control
     _pUi->noteView->setSelectionBehavior(QAbstractItemView::SelectRows);
     _pUi->noteView->setSelectionMode(QAbstractItemView::ExtendedSelection);
-
 
     _pUi->btnUpdateDataFile->setVisible(false);
 
@@ -53,8 +51,8 @@ void NotesDockWidget::addNoteRow()
 
 void NotesDockWidget::onRegisterInserted(const QModelIndex &parent, int first, int last)
 {
-    Q_UNUSED(parent);
-    Q_UNUSED(last);
+    Q_UNUSED(parent)
+    Q_UNUSED(last)
 
     /* select the first new row, this will also make the row visible */
     _pUi->noteView->selectRow(first);
@@ -69,7 +67,7 @@ void NotesDockWidget::removeNoteRow()
         rows << idx.row();
     }
 
-    qSort(rows.begin(), rows.end(), qGreater<int>());
+    std::sort(rows.begin(), rows.end(), std::greater<int>());
 
     for (int i: rows)
     {

--- a/src/customwidgets/notesdockwidget.cpp
+++ b/src/customwidgets/notesdockwidget.cpp
@@ -19,7 +19,7 @@ NotesDockWidget::NotesDockWidget(NoteModel *pNoteModel, GuiModel *pGuiModel, QWi
     /* Don't stretch columns */
     _pUi->noteView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     /* Except following columns */
-    _pUi->noteView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    _pUi->noteView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Stretch);
 
     // Select using click, shift and control
     _pUi->noteView->setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -446,8 +446,7 @@ void MainWindow::addNoteToGraph()
                                          "", &ok);
     if (ok)
     {
-        newNote.setKeyData(_pGraphView->pixelToKey(_lastRightClickPos.x()));
-        newNote.setValueData(_pGraphView->pixelToValue(_lastRightClickPos.y()));
+        newNote.setNotePosition(_pGraphView->pixelToPointF(_lastRightClickPos));
         newNote.setText(text);
 
         _pNoteModel->add(newNote);

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -445,7 +445,9 @@ void MainWindow::addNoteToGraph()
     if (ok)
     {
         // TODO: Do smart caluclation to put note relative to arrow
-        Note newNote(text, _pGraphView->pixelToPointF(_lastRightClickPos));
+        Note newNote(text,
+                     _pGraphView->pixelToPointF(_lastRightClickPos),
+                     _pGraphView->pixelToPointF(_lastRightClickPos + QPoint(20, 20)));
         _pNoteModel->add(newNote);
     }
 }

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -438,17 +438,14 @@ void MainWindow::showRegisterDialog(QString mbcFile)
 
 void MainWindow::addNoteToGraph()
 {
-    Note newNote;
-
     bool ok;
     QString text = QInputDialog::getText(this, tr("Add note"),
                                          tr("Note Text:"), QLineEdit::Normal,
                                          "", &ok);
     if (ok)
     {
-        newNote.setNotePosition(_pGraphView->pixelToPointF(_lastRightClickPos));
-        newNote.setText(text);
-
+        // TODO: Do smart caluclation to put note relative to arrow
+        Note newNote(text, _pGraphView->pixelToPointF(_lastRightClickPos));
         _pNoteModel->add(newNote);
     }
 }

--- a/src/graphview/basicgraphview.cpp
+++ b/src/graphview/basicgraphview.cpp
@@ -394,7 +394,7 @@ void BasicGraphView::handleNoteTextChanged(const quint32 idx)
 
 void BasicGraphView::handleNoteAdded(const quint32 idx)
 {
-    auto newNote =new NoteItem(_pPlot,
+    auto newNote = std::make_shared<NoteItem>(_pPlot,
                                               _pNoteModel->textData(idx),
                                               _pNoteModel->notePosition(idx),
                                               _pNoteModel->arrowPosition(idx));
@@ -406,7 +406,6 @@ void BasicGraphView::handleNoteAdded(const quint32 idx)
 
 void BasicGraphView::handleNoteRemoved(const quint32 idx)
 {
-    _pPlot->removeItem(_notesItems[idx]);
     _notesItems.removeAt(idx);
     _pPlot->replot();
 }
@@ -478,7 +477,7 @@ void BasicGraphView::mousePress(QMouseEvent *event)
         QCPAbstractItem * pItem = _pPlot->itemAt(event->pos(), false);
         for(int idx = 0; idx < _notesItems.size(); idx++)
         {
-            if (_notesItems[idx] == pItem)
+            if (_notesItems[idx]->isItem(pItem))
             {
                 _pDraggedNoteIdx = idx;
                 break;
@@ -488,7 +487,7 @@ void BasicGraphView::mousePress(QMouseEvent *event)
         if (_pDraggedNoteIdx != NO_DRAGGED_NOTE)
         {
             /* Save cursor offset */
-            _pixelOffset = event->pos() - _notesItems[_pDraggedNoteIdx]->topLeft->pixelPosition().toPoint();
+            _pixelOffset = event->pos() - _notesItems[_pDraggedNoteIdx]->getNotePosition();
 
             /* Ignore global drag */
             /* Disable range drag when note item is selected */

--- a/src/graphview/basicgraphview.cpp
+++ b/src/graphview/basicgraphview.cpp
@@ -13,6 +13,9 @@
 #include "myqcpaxis.h"
 #include "basicgraphview.h"
 #include "graphviewzoom.h"
+#include "noteitem.h"
+
+const static quint32 NO_DRAGGED_NOTE = 0xFFFFFFFF;
 
 BasicGraphView::BasicGraphView(GuiModel * pGuiModel, GraphDataModel * pGraphDataModel, NoteModel *pNoteModel, MyQCustomPlot * pPlot, QObject *parent) :
     QObject(parent)
@@ -79,15 +82,14 @@ BasicGraphView::BasicGraphView(GuiModel * pGuiModel, GraphDataModel * pGraphData
    connect(_pPlot, SIGNAL(beforeReplot()), this, SLOT(handleSamplePoints()));
 
    // Note model
-   connect(_pNoteModel, SIGNAL(valueDataChanged(const quint32)), this, SLOT(handleNoteValueDataChanged(const quint32)));
-   connect(_pNoteModel, SIGNAL(keyDataChanged(const quint32)), this, SLOT(handleNoteKeyDataChanged(const quint32)));
+   connect(_pNoteModel, SIGNAL(notePositionChanged(const quint32)), this, SLOT(handleNotePositionChanged(const quint32)));
    connect(_pNoteModel, SIGNAL(textChanged(const quint32)), this, SLOT(handleNoteTextChanged(const quint32)));
    connect(_pNoteModel, SIGNAL(added(const quint32)), this, SLOT(handleNoteAdded(const quint32)));
    connect(_pNoteModel, SIGNAL(removed(const quint32)), this, SLOT(handleNoteRemoved(const quint32)));
 
-   _pDraggedNoteIdx = -1;
-   _pixelXOffset = 0;
-   _pixelYOffset = 0;
+   _pDraggedNoteIdx = NO_DRAGGED_NOTE;
+   _pixelOffset.setX(0);
+   _pixelOffset.setY(0);
 
    QPen markerPen;
    markerPen.setWidth(2);
@@ -159,14 +161,10 @@ bool BasicGraphView::valuesUnderCursor(QList<double> &valueList)
 
 }
 
-double BasicGraphView::pixelToKey(double pixel)
+QPointF BasicGraphView::pixelToPointF(const QPointF& pixel) const
 {
-    return _pPlot->xAxis->pixelToCoord(pixel);
-}
-
-double BasicGraphView::pixelToValue(double pixel)
-{
-    return _pPlot->yAxis->pixelToCoord(pixel);
+    return QPointF(_pPlot->xAxis->pixelToCoord(pixel.x()),
+                   _pPlot->yAxis->pixelToCoord(pixel.y()));
 }
 
 double BasicGraphView::pixelToClosestKey(double pixel)
@@ -375,15 +373,16 @@ void BasicGraphView::setEndMarker()
     _pPlot->replot();
 }
 
-void BasicGraphView::handleNoteValueDataChanged(const quint32 idx)
+void BasicGraphView::handleNoteArrowPositionChanged(const quint32 idx)
 {
-    _notesItems[idx]->position->setCoords(QPointF(_pNoteModel->keyData(idx), _pNoteModel->valueData(idx))); // place position at left/top of axis rect
+    _notesItems[idx]->setArrowPosition(_pNoteModel->arrowPosition(idx));
     _pPlot->replot();
 }
 
-void BasicGraphView::handleNoteKeyDataChanged(const quint32 idx)
+void BasicGraphView::handleNotePositionChanged(const quint32 idx)
 {
-    _notesItems[idx]->position->setCoords(QPointF(_pNoteModel->keyData(idx), _pNoteModel->valueData(idx))); // place position at left/top of axis rect
+    _notesItems[idx]->setArrowPosition(_pNoteModel->arrowPosition(idx));
+    _notesItems[idx]->position->setCoords(_pNoteModel->notePosition(idx)); // place position at left/top of axis rect
     _pPlot->replot();
 }
 
@@ -395,16 +394,9 @@ void BasicGraphView::handleNoteTextChanged(const quint32 idx)
 
 void BasicGraphView::handleNoteAdded(const quint32 idx)
 {
-    QCPItemText *pTextLabel = new QCPItemText(_pPlot);
+    NoteItem *pNoteItem = new NoteItem(_pPlot, _pNoteModel->textData(idx), _pNoteModel->notePosition(idx));
 
-    pTextLabel->setPositionAlignment(Qt::AlignTop|Qt::AlignLeft);
-    pTextLabel->setTextAlignment(Qt::AlignLeft);
-    pTextLabel->setText(_pNoteModel->textData(idx));
-    pTextLabel->position->setType(QCPItemPosition::ptPlotCoords);
-    pTextLabel->setPen(QPen(Qt::black)); // show black border around text
-    pTextLabel->position->setCoords(QPointF(_pNoteModel->keyData(idx), _pNoteModel->valueData(idx))); // place position at left/top of axis rect
-
-    _notesItems.append(pTextLabel);
+    _notesItems.append(pNoteItem);
 
     _pPlot->replot();
 }
@@ -479,7 +471,7 @@ void BasicGraphView::mousePress(QMouseEvent *event)
     }
     else
     {
-        _pDraggedNoteIdx = -1;
+        _pDraggedNoteIdx = NO_DRAGGED_NOTE;
         QCPAbstractItem * pItem = _pPlot->itemAt(event->pos(), false);
         for(int idx = 0; idx < _notesItems.size(); idx++)
         {
@@ -490,11 +482,10 @@ void BasicGraphView::mousePress(QMouseEvent *event)
             }
         }
 
-        if (_pDraggedNoteIdx != -1)
+        if (_pDraggedNoteIdx != NO_DRAGGED_NOTE)
         {
             /* Save cursor offset */
-            _pixelXOffset = event->pos().x() - _notesItems[_pDraggedNoteIdx]->topLeft->pixelPosition().x();
-            _pixelYOffset = event->pos().y() - _notesItems[_pDraggedNoteIdx]->topLeft->pixelPosition().y();
+            _pixelOffset = event->pos() - _notesItems[_pDraggedNoteIdx]->topLeft->pixelPosition().toPoint();
 
             /* Ignore global drag */
             /* Disable range drag when note item is selected */
@@ -527,7 +518,7 @@ void BasicGraphView::mouseRelease(QMouseEvent *event)
 
     (void)_pGraphViewZoom->handleMouseRelease();
 
-    _pDraggedNoteIdx = -1;
+    _pDraggedNoteIdx = NO_DRAGGED_NOTE;
 
     /* Always re-enable range drag */
     _pPlot->setInteraction(QCP::iRangeDrag, true);
@@ -575,10 +566,9 @@ void BasicGraphView::mouseMove(QMouseEvent *event)
             {
                 /* Already handled by graph zoom */
             }
-            else if ((_pDraggedNoteIdx != -1) && _pNoteModel->draggable(_pDraggedNoteIdx))
+            else if ((_pDraggedNoteIdx != NO_DRAGGED_NOTE) && _pNoteModel->draggable(_pDraggedNoteIdx))
             {
-                _pNoteModel->setKeyData(_pDraggedNoteIdx, pixelToKey(event->pos().x() - _pixelXOffset));
-                _pNoteModel->setValueData(_pDraggedNoteIdx, pixelToValue(event->pos().y() - _pixelYOffset));
+                _pNoteModel->setNotePostion(_pDraggedNoteIdx, pixelToPointF(event->pos() - _pixelOffset));
             }
             else
             {

--- a/src/graphview/basicgraphview.cpp
+++ b/src/graphview/basicgraphview.cpp
@@ -394,10 +394,10 @@ void BasicGraphView::handleNoteTextChanged(const quint32 idx)
 
 void BasicGraphView::handleNoteAdded(const quint32 idx)
 {
-    auto newNote = std::make_shared<NoteItem>(_pPlot,
+    auto newNote = QSharedPointer<NoteItem>( new NoteItem(_pPlot,
                                               _pNoteModel->textData(idx),
                                               _pNoteModel->notePosition(idx),
-                                              _pNoteModel->arrowPosition(idx));
+                                              _pNoteModel->arrowPosition(idx)));
 
     _notesItems.append(newNote);
 

--- a/src/graphview/basicgraphview.cpp
+++ b/src/graphview/basicgraphview.cpp
@@ -382,7 +382,7 @@ void BasicGraphView::handleNoteArrowPositionChanged(const quint32 idx)
 void BasicGraphView::handleNotePositionChanged(const quint32 idx)
 {
     _notesItems[idx]->setArrowPosition(_pNoteModel->arrowPosition(idx));
-    _notesItems[idx]->position->setCoords(_pNoteModel->notePosition(idx)); // place position at left/top of axis rect
+    _notesItems[idx]->setNotePosition(_pNoteModel->notePosition(idx)); // place position at left/top of axis rect
     _pPlot->replot();
 }
 
@@ -394,9 +394,12 @@ void BasicGraphView::handleNoteTextChanged(const quint32 idx)
 
 void BasicGraphView::handleNoteAdded(const quint32 idx)
 {
-    NoteItem *pNoteItem = new NoteItem(_pPlot, _pNoteModel->textData(idx), _pNoteModel->notePosition(idx));
+    auto newNote =new NoteItem(_pPlot,
+                                              _pNoteModel->textData(idx),
+                                              _pNoteModel->notePosition(idx),
+                                              _pNoteModel->arrowPosition(idx));
 
-    _notesItems.append(pNoteItem);
+    _notesItems.append(newNote);
 
     _pPlot->replot();
 }

--- a/src/graphview/basicgraphview.h
+++ b/src/graphview/basicgraphview.h
@@ -3,8 +3,6 @@
 
 #include <QObject>
 
-#include <memory>    // std::shared_ptr
-
 #include "myqcustomplot.h"
 #include "noteitem.h"
 
@@ -93,7 +91,7 @@ private:
     double getClosestPoint(double coordinate);
 
     QVector<QString> _tickLabels;
-    QList< std::shared_ptr<NoteItem> > _notesItems;
+    QList< QSharedPointer<NoteItem> > _notesItems;
 
     quint32 _pDraggedNoteIdx;
     QPoint _pixelOffset;

--- a/src/graphview/basicgraphview.h
+++ b/src/graphview/basicgraphview.h
@@ -2,6 +2,9 @@
 #define BASICGRAPHVIEW_H
 
 #include <QObject>
+
+#include <memory>    // std::shared_ptr
+
 #include "myqcustomplot.h"
 #include "noteitem.h"
 

--- a/src/graphview/basicgraphview.h
+++ b/src/graphview/basicgraphview.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include "myqcustomplot.h"
+#include "noteitem.h"
 
 
 /* forward declaration */
@@ -31,8 +32,7 @@ public:
     qint32 graphDataSize();
     bool valuesUnderCursor(QList<double> &valueList);
 
-    double pixelToKey(double pixel);
-    double pixelToValue(double pixel);
+    QPointF pixelToPointF(const QPointF& pixel) const;
     double pixelToClosestKey(double pixel);
     double pixelToClosestValue(double pixel);
 
@@ -54,8 +54,8 @@ public slots:
     virtual void setStartMarker();
     virtual void setEndMarker();
 
-    virtual void handleNoteValueDataChanged(const quint32 idx);
-    virtual void handleNoteKeyDataChanged(const quint32 idx);
+    virtual void handleNoteArrowPositionChanged(const quint32 idx);
+    virtual void handleNotePositionChanged(const quint32 idx);
     virtual void handleNoteTextChanged(const quint32 idx);
     virtual void handleNoteAdded(const quint32 idx);
     virtual void handleNoteRemoved(const quint32 idx);
@@ -90,11 +90,10 @@ private:
     double getClosestPoint(double coordinate);
 
     QVector<QString> _tickLabels;
-    QList<QCPItemText *> _notesItems;
+    QList<NoteItem *> _notesItems;
 
-    qint32 _pDraggedNoteIdx;
-    qint32 _pixelXOffset;
-    qint32 _pixelYOffset;
+    quint32 _pDraggedNoteIdx;
+    QPoint _pixelOffset;
 
     GraphViewZoom* _pGraphViewZoom;
 

--- a/src/graphview/basicgraphview.h
+++ b/src/graphview/basicgraphview.h
@@ -90,7 +90,7 @@ private:
     double getClosestPoint(double coordinate);
 
     QVector<QString> _tickLabels;
-    QList<NoteItem*> _notesItems;
+    QList< std::shared_ptr<NoteItem> > _notesItems;
 
     quint32 _pDraggedNoteIdx;
     QPoint _pixelOffset;

--- a/src/graphview/basicgraphview.h
+++ b/src/graphview/basicgraphview.h
@@ -90,7 +90,7 @@ private:
     double getClosestPoint(double coordinate);
 
     QVector<QString> _tickLabels;
-    QList<NoteItem *> _notesItems;
+    QList<NoteItem*> _notesItems;
 
     quint32 _pDraggedNoteIdx;
     QPoint _pixelOffset;

--- a/src/graphview/noteitem.cpp
+++ b/src/graphview/noteitem.cpp
@@ -4,61 +4,81 @@ NoteItem::NoteItem(MyQCustomPlot* pPlot,
                    const QString& rText,
                    const QPointF& rPosition,
                    const QPointF& rArrowPosition)
-    : QCPItemText(pPlot),
-      _arrow(pPlot)
+    : _note(nullptr),
+      _arrow(nullptr),
+      _plot(pPlot)
 {  
-    setPositionAlignment(Qt::AlignTop|Qt::AlignLeft);
-    setTextAlignment(Qt::AlignLeft);
-    setText(rText);
-    position->setType(QCPItemPosition::ptPlotCoords);
-    setPen(QPen(Qt::black)); // show black border around text
-    position->setCoords(rPosition); // place position at left/top of axis rect
+    _note = new QCPItemText(_plot);
+    _arrow = new QCPItemLine(_plot);
 
-    _arrow.setHead(QCPLineEnding::esSpikeArrow);
+    _note->setPositionAlignment(Qt::AlignBottom|Qt::AlignRight);
+    _note->setTextAlignment(Qt::AlignLeft);
+    _note->setText(rText);
+    _note->position->setType(QCPItemPosition::ptPlotCoords);
+    _note->setPen(QPen(Qt::black)); // show black border around text
+    _note->position->setCoords(rPosition); // place position at left/top of axis rect
+
+    _arrow->setHead(QCPLineEnding::esSpikeArrow);
     setArrowPosition(rArrowPosition);
 }
 
 NoteItem::~NoteItem()
 {
-    parentPlot()->removeItem(&_arrow);
+    _plot->removeItem(_note);
+    _plot->removeItem(_arrow);
 }
 
 void NoteItem::setArrowPosition(const QPointF& rPosition)
 {
-    _arrow.end->setCoords(rPosition);
+    _arrow->end->setCoords(rPosition);
     updateArrowAnchor();
 }
 
 void NoteItem::setNotePosition(const QPointF& rPosition)
 {
-    position->setCoords(rPosition); // place position at left/top of axis rect
+    _note->position->setCoords(rPosition); // place position at left/top of axis rect
     updateArrowAnchor();
+}
+
+void NoteItem::setText(const QString& text)
+{
+    _note->setText(text);
+}
+
+QPoint NoteItem::getNotePosition() const
+{
+    return _note->topLeft->pixelPosition().toPoint();
+}
+
+bool NoteItem::isItem(QCPAbstractItem * pItem) const
+{
+    return pItem == _note;
 }
 
 void NoteItem::updateArrowAnchor()
 {
-    QPointF diff = _arrow.end->coords() - position->coords();
+    QPointF diff = _arrow->end->pixelPosition() - _note->topLeft->pixelPosition();
 
     if (std::abs(diff.x()) > std::abs(diff.y()))
     {
-        if (diff.x() > 0 )
+        if (diff.x() > 0)
         {
-            _arrow.start->setParentAnchor(right);
+            _arrow->start->setParentAnchor(_note->right);
         }
         else
         {
-            _arrow.start->setParentAnchor(left);
+            _arrow->start->setParentAnchor(_note->left);
         }
     }
     else
     {
-        if (diff.y() > 0 )
+        if (diff.y() > 0)
         {
-            _arrow.start->setParentAnchor(top);
+            _arrow->start->setParentAnchor(_note->bottom);
         }
         else
         {
-            _arrow.start->setParentAnchor(bottom);
+            _arrow->start->setParentAnchor(_note->top);
         }
     }
 }

--- a/src/graphview/noteitem.cpp
+++ b/src/graphview/noteitem.cpp
@@ -1,0 +1,28 @@
+#include "noteitem.h"
+
+
+NoteItem::NoteItem(MyQCustomPlot* pPlot, const QString& rText, const QPointF& rPosition)
+    : QCPItemText(pPlot),
+      _arrow(pPlot)
+{  
+    setPositionAlignment(Qt::AlignTop|Qt::AlignLeft);
+    setTextAlignment(Qt::AlignLeft);
+    setText(rText);
+    position->setType(QCPItemPosition::ptPlotCoords);
+    setPen(QPen(Qt::black)); // show black border around text
+    position->setCoords(rPosition); // place position at left/top of axis rect
+
+    _arrow.start->setParentAnchor(bottom);
+    _arrow.end->setCoords(rPosition);
+    _arrow.setHead(QCPLineEnding::esSpikeArrow);
+}
+
+NoteItem::~NoteItem()
+{
+
+}
+
+void NoteItem::setArrowPosition(const QPointF& rPosition)
+{
+    _arrow.end->setCoords(rPosition);
+}

--- a/src/graphview/noteitem.cpp
+++ b/src/graphview/noteitem.cpp
@@ -1,7 +1,9 @@
 #include "noteitem.h"
 
-
-NoteItem::NoteItem(MyQCustomPlot* pPlot, const QString& rText, const QPointF& rPosition)
+NoteItem::NoteItem(MyQCustomPlot* pPlot,
+                   const QString& rText,
+                   const QPointF& rPosition,
+                   const QPointF& rArrowPosition)
     : QCPItemText(pPlot),
       _arrow(pPlot)
 {  
@@ -12,17 +14,51 @@ NoteItem::NoteItem(MyQCustomPlot* pPlot, const QString& rText, const QPointF& rP
     setPen(QPen(Qt::black)); // show black border around text
     position->setCoords(rPosition); // place position at left/top of axis rect
 
-    _arrow.start->setParentAnchor(bottom);
-    _arrow.end->setCoords(rPosition);
     _arrow.setHead(QCPLineEnding::esSpikeArrow);
+    setArrowPosition(rArrowPosition);
 }
 
 NoteItem::~NoteItem()
 {
-
+    parentPlot()->removeItem(&_arrow);
 }
 
 void NoteItem::setArrowPosition(const QPointF& rPosition)
 {
     _arrow.end->setCoords(rPosition);
+    updateArrowAnchor();
+}
+
+void NoteItem::setNotePosition(const QPointF& rPosition)
+{
+    position->setCoords(rPosition); // place position at left/top of axis rect
+    updateArrowAnchor();
+}
+
+void NoteItem::updateArrowAnchor()
+{
+    QPointF diff = _arrow.end->coords() - position->coords();
+
+    if (std::abs(diff.x()) > std::abs(diff.y()))
+    {
+        if (diff.x() > 0 )
+        {
+            _arrow.start->setParentAnchor(right);
+        }
+        else
+        {
+            _arrow.start->setParentAnchor(left);
+        }
+    }
+    else
+    {
+        if (diff.y() > 0 )
+        {
+            _arrow.start->setParentAnchor(top);
+        }
+        else
+        {
+            _arrow.start->setParentAnchor(bottom);
+        }
+    }
 }

--- a/src/graphview/noteitem.h
+++ b/src/graphview/noteitem.h
@@ -7,13 +7,19 @@
 class NoteItem : public QCPItemText
 {
 public:
-    NoteItem(MyQCustomPlot* pPlot, const QString& rText, const QPointF& rPosition);
+    NoteItem(MyQCustomPlot* pPlot,
+             const QString& rText,
+             const QPointF& rPosition,
+             const QPointF& rArrowPosition);
     virtual ~NoteItem();
 
     void setArrowPosition(const QPointF& rPosition);
+    void setNotePosition(const QPointF& rPosition);
 
 private:
     QCPItemLine _arrow;
+
+    void updateArrowAnchor();
 };
 
 #endif // NOTEITEM_H

--- a/src/graphview/noteitem.h
+++ b/src/graphview/noteitem.h
@@ -4,7 +4,7 @@
 #include "qcustomplot.h"
 #include "myqcustomplot.h"
 
-class NoteItem : public QCPItemText
+class NoteItem
 {
 public:
     NoteItem(MyQCustomPlot* pPlot,
@@ -15,9 +15,15 @@ public:
 
     void setArrowPosition(const QPointF& rPosition);
     void setNotePosition(const QPointF& rPosition);
+    void setText(const QString& text);
+
+    QPoint getNotePosition() const;
+    bool isItem(QCPAbstractItem * pItem) const;
 
 private:
-    QCPItemLine _arrow;
+    QCPItemText* _note;
+    QCPItemLine* _arrow;
+    MyQCustomPlot* _plot;
 
     void updateArrowAnchor();
 };

--- a/src/graphview/noteitem.h
+++ b/src/graphview/noteitem.h
@@ -1,0 +1,19 @@
+#ifndef NOTEITEM_H
+#define NOTEITEM_H
+
+#include "qcustomplot.h"
+#include "myqcustomplot.h"
+
+class NoteItem : public QCPItemText
+{
+public:
+    NoteItem(MyQCustomPlot* pPlot, const QString& rText, const QPointF& rPosition);
+    virtual ~NoteItem();
+
+    void setArrowPosition(const QPointF& rPosition);
+
+private:
+    QCPItemLine _arrow;
+};
+
+#endif // NOTEITEM_H

--- a/src/importexport/datafileexporter.cpp
+++ b/src/importexport/datafileexporter.cpp
@@ -337,10 +337,12 @@ QString DataFileExporter::createNoteRows(void)
 
         noteline.append("//Note");
 
-        dataString = Util::formatDoubleForExport(_pNoteModel->keyData(idx));
+        const QPointF& position = _pNoteModel->notePosition(idx);
+
+        dataString = Util::formatDoubleForExport(position.x());
         noteline.append(Util::separatorCharacter() + dataString);
 
-        dataString = Util::formatDoubleForExport(_pNoteModel->valueData(idx));
+        dataString = Util::formatDoubleForExport(position.y());
         noteline.append(Util::separatorCharacter() + dataString);
 
         noteline.append(Util::separatorCharacter() + '"' + _pNoteModel->textData(idx) + '"');

--- a/src/importexport/datafileparser.cpp
+++ b/src/importexport/datafileparser.cpp
@@ -396,19 +396,10 @@ bool DataFileParser::parseNoteField(QStringList noteFieldList, Note * pNote)
     if (noteFieldList.size() == 4)
     {
         const double key = parseDouble(noteFieldList[1], &bOk);
-        if (bOk)
-        {
-            pNote->setKeyData(key);
-        }
-        else
-        {
-            bSucces = false;
-        }
-
         const double value = parseDouble(noteFieldList[2], &bOk);
         if (bOk)
         {
-            pNote->setValueData(value);
+            pNote->setNotePosition( QPointF(key, value));
         }
         else
         {

--- a/src/importexport/datafileparser.cpp
+++ b/src/importexport/datafileparser.cpp
@@ -395,11 +395,21 @@ bool DataFileParser::parseNoteField(QStringList noteFieldList, Note * pNote)
 
     if (noteFieldList.size() == 4)
     {
-        const double key = parseDouble(noteFieldList[1], &bOk);
-        const double value = parseDouble(noteFieldList[2], &bOk);
+        QPointF notePosition;
+        notePosition.setX(parseDouble(noteFieldList[1], &bOk));
+
         if (bOk)
         {
-            pNote->setNotePosition( QPointF(key, value));
+            notePosition.setY(parseDouble(noteFieldList[2], &bOk));
+        }
+        else
+        {
+            bSucces = false;
+        }
+
+        if (bOk)
+        {
+            pNote->setNotePosition(notePosition);
         }
         else
         {

--- a/src/models/note.cpp
+++ b/src/models/note.cpp
@@ -8,6 +8,15 @@ Note::Note() :
 {
 }
 
+Note::Note(const QString& text, const QPointF& position)
+    : _arrowPosition(position),
+      _relativeNotePosition(position),
+      _text(text),
+      _bDraggable(false)
+{
+
+}
+
 QString Note::text() const
 {
     return _text;
@@ -24,9 +33,14 @@ const QPointF& Note::arrowPosition() const
     return _arrowPosition;
 }
 
-void Note::setArrowPosition(const QPointF &position)
+void Note::setArrowTimePosition(const double& position)
 {
-    _arrowPosition = position;
+    _arrowPosition.setX(position);
+}
+
+void Note::setArrowValuePosition(const double& position)
+{
+    _arrowPosition.setY(position);
 }
 
 const QPointF& Note::notePosition() const

--- a/src/models/note.cpp
+++ b/src/models/note.cpp
@@ -1,11 +1,11 @@
 #include "note.h"
 
-Note::Note()
+Note::Note() :
+    _arrowPosition(0.0, 0.0),
+    _relativeNotePosition(0.0, 0.0),
+    _text(""),
+    _bDraggable(false)
 {
-    _valueData = 0;
-    _keyData = 0;
-    _text = QString("");
-    _bDraggable = false;
 }
 
 QString Note::text() const
@@ -18,24 +18,30 @@ void Note::setText(const QString &text)
     _text = text;
 }
 
-double Note::valueData() const
+
+const QPointF& Note::arrowPosition() const
 {
-    return _valueData;
+    return _arrowPosition;
 }
 
-void Note::setValueData(double valueData)
+void Note::setArrowPosition(const QPointF &position)
 {
-    _valueData = valueData;
+    _arrowPosition = position;
 }
 
-double Note::keyData() const
+const QPointF& Note::notePosition() const
 {
-    return _keyData;
+    return _relativeNotePosition;
 }
 
-void Note::setKeyData(double keyData)
+void Note::setNotePosition(const QPointF &position)
 {
-    _keyData = keyData;
+    _relativeNotePosition = position;
+}
+
+void Note::setNotePosition(double key, double value)
+{
+    setNotePosition(QPointF(key, value));
 }
 
 bool Note::draggable() const

--- a/src/models/note.cpp
+++ b/src/models/note.cpp
@@ -17,6 +17,15 @@ Note::Note(const QString& text, const QPointF& position)
 
 }
 
+Note::Note(const QString& text, const QPointF& notePosition, const QPointF& arrowPosition)
+    : _arrowPosition(arrowPosition),
+      _relativeNotePosition(notePosition),
+      _text(text),
+      _bDraggable(false)
+{
+
+}
+
 QString Note::text() const
 {
     return _text;

--- a/src/models/note.h
+++ b/src/models/note.h
@@ -8,13 +8,15 @@ class Note
 {
 public:
     Note();
+    Note(const QString& text, const QPointF& position);
 
     const QPointF& arrowPosition() const;
     const QPointF& notePosition() const;
     QString text() const;
     bool draggable() const;
 
-    void setArrowPosition(const QPointF& position);
+    void setArrowTimePosition(const double& position);
+    void setArrowValuePosition(const double& position);
     void setNotePosition(const QPointF& position);
     void setNotePosition(double key, double value);
     void setText(const QString &text);

--- a/src/models/note.h
+++ b/src/models/note.h
@@ -9,6 +9,7 @@ class Note
 public:
     Note();
     Note(const QString& text, const QPointF& position);
+    Note(const QString& text, const QPointF& notePosition, const QPointF& arrowPosition);
 
     const QPointF& arrowPosition() const;
     const QPointF& notePosition() const;

--- a/src/models/note.h
+++ b/src/models/note.h
@@ -1,6 +1,7 @@
 #ifndef NOTE_H
 #define NOTE_H
 
+#include <QPointF>
 #include <QString>
 
 class Note
@@ -8,20 +9,20 @@ class Note
 public:
     Note();
 
-
-    double valueData() const;
-    double keyData() const;
+    const QPointF& arrowPosition() const;
+    const QPointF& notePosition() const;
     QString text() const;
     bool draggable() const;
 
-    void setValueData(double valueData);
-    void setKeyData(double keyData);
+    void setArrowPosition(const QPointF& position);
+    void setNotePosition(const QPointF& position);
+    void setNotePosition(double key, double value);
     void setText(const QString &text);
     void setDraggable(bool state);
 
 private:
-    double _valueData;
-    double _keyData;
+    QPointF _arrowPosition;
+    QPointF _relativeNotePosition;
     QString _text;
     bool _bDraggable;
 

--- a/src/models/notemodel.cpp
+++ b/src/models/notemodel.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 
-enum role {
+enum column {
     DRAGGABLE = 0,
     KEY_DATA,
     VALUE_DATA,
@@ -44,17 +44,17 @@ QVariant NoteModel::headerData(int section, Qt::Orientation orientation, int rol
         {
             switch (section)
             {
-            case role::DRAGGABLE:
+            case column::DRAGGABLE:
                 return QString("Draggable");
-            case role::KEY_DATA:
+            case column::KEY_DATA:
                 return QString("Key");
-            case role::VALUE_DATA:
+            case column::VALUE_DATA:
                 return QString("Value");
-            case role::ARROW_POSITION_TIME:
+            case column::ARROW_POSITION_TIME:
                 return QString("Arrow time");
-            case role::ARROW_POSITION_VALUE:
+            case column::ARROW_POSITION_VALUE:
                 return QString("Arrow value");
-            case role::TEXT:
+            case column::TEXT:
                 return QString("Text");
             default:
                 return QVariant();
@@ -76,14 +76,14 @@ int NoteModel::rowCount(const QModelIndex & /*parent*/) const
 
 int NoteModel::columnCount(const QModelIndex & /*parent*/) const
 {
-    return role::COUNT; // Number of visible members of struct
+    return column::COUNT; // Number of visible members of struct
 }
 
 QVariant NoteModel::data(const QModelIndex &index, int role) const
 {
     switch (index.column())
     {
-    case role::DRAGGABLE:
+    case column::DRAGGABLE:
         if (role == Qt::CheckStateRole)
         {
             if (_noteList[index.row()].draggable())
@@ -96,31 +96,31 @@ QVariant NoteModel::data(const QModelIndex &index, int role) const
             }
         }
         break;
-    case role::KEY_DATA:
+    case column::KEY_DATA:
         if (role == Qt::DisplayRole)
         {
             return Util::formatTime(_noteList[index.row()].notePosition().x(), false);
         }
         break;
-    case role::VALUE_DATA:
+    case column::VALUE_DATA:
         if (role == Qt::DisplayRole)
         {
             return Util::formatDoubleForExport(_noteList[index.row()].notePosition().y());
         }
         break;
-    case role::ARROW_POSITION_TIME:
+    case column::ARROW_POSITION_TIME:
         if ((role == Qt::DisplayRole) || (role == Qt::EditRole))
         {
             return Util::formatTime(_noteList[index.row()].arrowPosition().x(), false);
         }
         break;
-    case role::ARROW_POSITION_VALUE:
+    case column::ARROW_POSITION_VALUE:
         if ((role == Qt::DisplayRole) || (role == Qt::EditRole))
         {
             return Util::formatDoubleForExport(_noteList[index.row()].arrowPosition().y());
         }
         break;
-    case role::TEXT:
+    case column::TEXT:
         if ((role == Qt::DisplayRole) || (role == Qt::EditRole))
         {
             return _noteList[index.row()].text();
@@ -141,7 +141,7 @@ bool NoteModel::setData(const QModelIndex &index, const QVariant &value, int rol
 
     switch (index.column())
     {
-    case role::DRAGGABLE:
+    case column::DRAGGABLE:
         if (role == Qt::CheckStateRole)
         {
             if (value == Qt::Checked)
@@ -154,7 +154,7 @@ bool NoteModel::setData(const QModelIndex &index, const QVariant &value, int rol
             }
         }
         break;
-    case role::ARROW_POSITION_TIME:
+    case column::ARROW_POSITION_TIME:
         if (role == Qt::EditRole)
         {
             // TODO: What if invalid time?
@@ -162,13 +162,13 @@ bool NoteModel::setData(const QModelIndex &index, const QVariant &value, int rol
             setArrowTimePosition(index.row(), timePos );
         }
         break;
-    case role::ARROW_POSITION_VALUE:
+    case column::ARROW_POSITION_VALUE:
         if (role == Qt::EditRole)
         {
             setArrowValuePosition(index.row(), value.toDouble());
         }
         break;
-    case role::TEXT:
+    case column::TEXT:
         if (role == Qt::EditRole)
         {
             setText(index.row(), value.toString());
@@ -201,12 +201,12 @@ Qt::ItemFlags NoteModel::flags(const QModelIndex &index) const
 
     switch (index.column())
     {
-    case role::DRAGGABLE:
+    case column::DRAGGABLE:
         flags |=  Qt::ItemIsUserCheckable;
         break;
-    case role::ARROW_POSITION_TIME:
-    case role::ARROW_POSITION_VALUE:
-    case role::TEXT:
+    case column::ARROW_POSITION_TIME:
+    case column::ARROW_POSITION_VALUE:
+    case column::TEXT:
         flags |= Qt::ItemIsEditable;
         break;
     default:

--- a/src/models/notemodel.h
+++ b/src/models/notemodel.h
@@ -41,7 +41,8 @@ public:
     bool draggable(quint32 idx);
     bool isNotesDataUpdated();
 
-    void setArrowPosition(qint32 idx, const QPointF& value);
+    void setArrowTimePosition(qint32 idx, const double& value);
+    void setArrowValuePosition(qint32 idx, const double& value);
     void setNotePostion(quint32 idx, const QPointF& value);
     void setText(quint32 idx, QString text);
     void setDraggable(quint32 idx, bool bState);

--- a/src/models/notemodel.h
+++ b/src/models/notemodel.h
@@ -2,6 +2,7 @@
 #define NOTEMODEL_H
 
 #include <QObject>
+#include <QPointF>
 #include <QModelIndex>
 #include <QList>
 #include <QAbstractTableModel>
@@ -12,7 +13,7 @@ class NoteModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
-    explicit NoteModel(QObject *parent = 0);
+    explicit NoteModel(QObject *parent = nullptr);
 
     // Header:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
@@ -34,21 +35,21 @@ public:
     void remove(qint32 idx);
     void clear();
 
-    double valueData(quint32 idx);
-    double keyData(quint32 idx);
+    const QPointF& arrowPosition(qint32 idx) const;
+    const QPointF& notePosition(qint32 idx) const;
     QString textData(quint32 idx);
     bool draggable(quint32 idx);
     bool isNotesDataUpdated();
 
-    void setValueData(quint32 idx, double value);
-    void setKeyData(quint32 idx, double key);
+    void setArrowPosition(qint32 idx, const QPointF& value);
+    void setNotePostion(quint32 idx, const QPointF& value);
     void setText(quint32 idx, QString text);
     void setDraggable(quint32 idx, bool bState);
     void setNotesDataUpdated(bool bUpdated);
 
 signals:
-    void valueDataChanged(const quint32 idx);
-    void keyDataChanged(const quint32 idx);
+    void arrowPositionChanged(const quint32 idx);
+    void notePositionChanged(const quint32 idx);
     void textChanged(const quint32 idx);
     void draggableChanged(const quint32 idx);
     void notesDataUpdatedChanged();

--- a/src/src.pro
+++ b/src/src.pro
@@ -11,5 +11,7 @@ win32 {
     RC_ICONS = icon/application.ico
 }
 
+HEADERS +=
+
 
 

--- a/tests_integration/importexport/datafileparser/testdatafileparser.cpp
+++ b/tests_integration/importexport/datafileparser/testdatafileparser.cpp
@@ -92,13 +92,11 @@ void TestDataFileParser::parseModbusScopeNewFormat()
     QCOMPARE(fileData.colors, QList<QColor>() << QColor("#000000") << QColor("#0000FF"));
 
     Note note;
-    note.setValueData(1.667);
-    note.setKeyData(800.605);
+    note.setNotePosition(800.605, 1.667);
     note.setText("Test");
     QCOMPARE(fileData.notes.size(), 1);
     QCOMPARE(fileData.notes[0].text(), note.text());
-    QCOMPARE(fileData.notes[0].keyData(), note.keyData());
-    QCOMPARE(fileData.notes[0].valueData(), note.valueData());
+    QCOMPARE(fileData.notes[0].notePosition(), note.notePosition());
 
     QCOMPARE(spyParseError.count(), 0);
 }


### PR DESCRIPTION
This pull request solves #117 by adding arrows to notes. Importing of notes from data file should still work. 
I've also cleaned up parts of the Note / NoteModel.

There are some issues that should be solved, but not sure how yet :man_shrugging: 

# Open Issues:
* When clicking note for drag, note jumps
* Arrow position only editable through manage notes dialog
* Arrow position not stored in data file
* Arrow time position, formatting not easy (e.g. filling in just 10 jumps to 00:00:00,000)

Please test before merging :smile:  

![demo](https://user-images.githubusercontent.com/1345842/65278584-b6987700-db2c-11e9-9262-1a685a3a173e.gif)
