### PR TITLE
Remember mbc file

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -2,6 +2,17 @@
 
 The latest *ModbusScope* installer or standalone version can always be downloaded from the [release page](https://github.com/jgeudens/ModbusScope/releases).  
 
+## Unreleased
+
+* Various user experience improvements
+  * Replace check boxes with radio buttons
+  * Rename menu items
+  * Add extra menu items to tool bar
+* Reload previous mbc file when import mbc dialog is opened ([Github #156](https://github.com/jgeudens/ModbusScope/issues/156))
+* Improve documentation (fixed [Github #161](https://github.com/jgeudens/ModbusScope/issues/161) and open data file chapter)
+* Fix that marker points are visible when graph isn't ([Github #157](https://github.com/jgeudens/ModbusScope/issues/157))
+* Updated used libraries and internal improvements
+
 ## [v3.2.1](https://github.com/jgeudens/ModbusScope/releases/tag/3.2.1) (15/04/2021)
 
 ### Fixes

--- a/src/dialogs/importmbcdialog.cpp
+++ b/src/dialogs/importmbcdialog.cpp
@@ -145,7 +145,7 @@ void ImportMbcDialog::updateMbcRegisters(QString filePath)
     }
     else
     {
-        Util::showError(tr("The file can't be read."));
+        Util::showError(tr("The file (\"%1\") can't be read.").arg(filePath));
     }
 }
 

--- a/src/dialogs/importmbcdialog.cpp
+++ b/src/dialogs/importmbcdialog.cpp
@@ -55,27 +55,23 @@ ImportMbcDialog::~ImportMbcDialog()
     delete _pUi;
 }
 
-int ImportMbcDialog::exec(QString mbcPath)
+int ImportMbcDialog::exec()
 {
-    _mbcFilePath = mbcPath;
-    _pUi->lineMbcfile->setText(_mbcFilePath);
-
-    if (_mbcFilePath.length() > 0)
+    QString filePath = _pGuiModel->lastMbcImportedFile();
+    if (!filePath.isEmpty())
     {
         /* Auto load with supplied path */
-        updateMbcRegisters();
+        updateMbcRegisters(filePath);
+
+        _pUi->lineMbcfile->setText(filePath);
     }
     else
     {
         /* Skip auto load: no file path */
+        _pUi->lineMbcfile->setText("");
     }
 
     return QDialog::exec();
-}
-
-int ImportMbcDialog::exec(void)
-{
-    return exec(QString(""));
 }
 
 void ImportMbcDialog::selectMbcFile()
@@ -94,20 +90,14 @@ void ImportMbcDialog::selectMbcFile()
         auto fileList = dialog.selectedFiles();
         if (!fileList.isEmpty())
         {
-            _mbcFilePath = fileList.at(0);
+            QString filePath = fileList.at(0);
 
-            _pUi->lineMbcfile->setText(_mbcFilePath);
+            _pUi->lineMbcfile->setText(filePath);
 
-            _pGuiModel->setLastDir(QFileInfo(_mbcFilePath).dir().absolutePath());
+            _pGuiModel->setLastDir(QFileInfo(filePath).dir().absolutePath());
+            _pGuiModel->setLastMbcImportedFile(filePath);
 
-            if (QFile::exists(_mbcFilePath))
-            {
-                updateMbcRegisters();
-            }
-            else
-            {
-                Util::showError("No valid MBC file selected.");
-            }
+            updateMbcRegisters(filePath);
         }
     }
 }
@@ -125,9 +115,9 @@ void ImportMbcDialog::registerDataChanged()
     }
 }
 
-void ImportMbcDialog::updateMbcRegisters()
+void ImportMbcDialog::updateMbcRegisters(QString filePath)
 {
-    QFile file(_mbcFilePath);
+    QFile file(filePath);
     if (file.open(QIODevice::ReadOnly | QIODevice::Text))
     {
         QTextStream in(&file);

--- a/src/dialogs/importmbcdialog.h
+++ b/src/dialogs/importmbcdialog.h
@@ -23,7 +23,6 @@ public:
 
 public slots:
     int exec(void);
-    int exec(QString mbcPath);
 
 private slots:
     void selectMbcFile();
@@ -31,7 +30,7 @@ private slots:
 
 private:
 
-    void updateMbcRegisters();
+    void updateMbcRegisters(QString filePath);
 
     Ui::ImportMbcDialog *_pUi;
 
@@ -40,8 +39,6 @@ private:
     MbcRegisterModel * _pMbcRegisterModel;
 
     MbcRegisterFilter * _pTabProxyFilter;
-
-    QString _mbcFilePath;
 };
 
 #endif // IMPORTMBCDIALOG_H

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -436,7 +436,8 @@ void MainWindow::showRegisterDialog(QString mbcFile)
     }
     else
     {
-        registerDialog.exec(mbcFile);
+        _pGuiModel->setLastMbcImportedFile(mbcFile);
+        registerDialog.execWithMbcImport();
     }
 }
 

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -45,7 +45,7 @@ RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataM
     connect(shortcut, &QShortcut::activated, this, &RegisterDialog::removeRegisterRow);
 
     // Setup handler for buttons
-    connect(_pUi->btnImportFromMbc, &QPushButton::released, this, &RegisterDialog::showImportDialogDefault);
+    connect(_pUi->btnImportFromMbc, &QPushButton::released, this, &RegisterDialog::showImportDialog);
     connect(_pUi->btnAdd, &QPushButton::released, this, &RegisterDialog::addRegisterRow);
     connect(_pUi->btnRemove, &QPushButton::released, this, &RegisterDialog::removeRegisterRow);
     connect(_pGraphDataModel, &GraphDataModel::rowsInserted, this, &RegisterDialog::onRegisterInserted);
@@ -84,14 +84,9 @@ void RegisterDialog::done(int r)
     }
 }
 
-int RegisterDialog::exec()
+int RegisterDialog::execWithMbcImport()
 {
-    return QDialog::exec();
-}
-
-int RegisterDialog::exec(QString mbcFile)
-{
-    showImportDialog(mbcFile);
+    showImportDialog();
 
     return exec();
 }
@@ -101,17 +96,12 @@ void RegisterDialog::addRegisterRow()
     _pGraphDataModel->insertRow(_pGraphDataModel->size());
 }
 
-void RegisterDialog::showImportDialogDefault()
-{
-    showImportDialog(QString(""));
-}
-
-void RegisterDialog::showImportDialog(QString mbcPath)
+void RegisterDialog::showImportDialog()
 {
     MbcRegisterModel mbcRegisterModel(_pGraphDataModel);
     ImportMbcDialog importMbcDialog(_pGuiModel, _pGraphDataModel, &mbcRegisterModel, this);
 
-    if (importMbcDialog.exec(mbcPath) == QDialog::Accepted)
+    if (importMbcDialog.exec() == QDialog::Accepted)
     {
         QList<GraphData> regList = mbcRegisterModel.selectedRegisterList();
 

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -19,15 +19,12 @@ public:
     explicit RegisterDialog(GuiModel * pGuiModel, GraphDataModel *pGraphDataModel, SettingsModel *pSettingsModel, QWidget *parent = nullptr);
     ~RegisterDialog();
 
-
 public slots:
-    int exec();
-    int exec(QString mbcFile);
+    int execWithMbcImport();
 
 private slots:
     void done(int r);
-    void showImportDialogDefault();
-    void showImportDialog(QString mbcPath);
+    void showImportDialog();
     void addRegisterRow();
     void removeRegisterRow();
     void activatedCell(QModelIndex modelIndex);

--- a/src/models/guimodel.cpp
+++ b/src/models/guimodel.cpp
@@ -54,6 +54,7 @@ GuiModel::GuiModel(QObject *parent) : QObject(parent)
     {
         _lastDir = docPath[0];
     }
+    _lastMbcImportedFile = QString();
 
     _guiSettings.xScaleMode = AxisMode::SCALE_AUTO;
     _guiSettings.yScaleMode = AxisMode::SCALE_AUTO;
@@ -184,7 +185,6 @@ void GuiModel::setProjectFilePath(QString path)
     }
 }
 
-
 void GuiModel::setLastDir(QString dir)
 {
     _lastDir = dir;
@@ -193,6 +193,16 @@ void GuiModel::setLastDir(QString dir)
 QString GuiModel::lastDir()
 {
     return _lastDir;
+}
+
+void GuiModel::setLastMbcImportedFile(QString file)
+{
+    _lastMbcImportedFile = file;
+}
+
+QString GuiModel::lastMbcImportedFile()
+{
+    return _lastMbcImportedFile;
 }
 
 void GuiModel::setxAxisScale(AxisMode::AxisScaleOptions scaleMode)

--- a/src/models/guimodel.h
+++ b/src/models/guimodel.h
@@ -58,6 +58,7 @@ public:
     QString windowTitle();
     QString projectFilePath();
     QString lastDir();
+    QString lastMbcImportedFile();
     AxisMode::AxisScaleOptions xAxisScalingMode();
     quint32 xAxisSlidingSec();
     AxisMode::AxisScaleOptions  yAxisScalingMode();
@@ -76,6 +77,7 @@ public:
 
     void setProjectFilePath(QString path);
     void setLastDir(QString dir);
+    void setLastMbcImportedFile(QString file);
     void setMarkerExpressionMask(quint32 mask);
 
 public slots:
@@ -147,6 +149,7 @@ private:
 
     QString _projectFilePath;
     QString _lastDir; // Last directory opened for import/export/load project
+    QString _lastMbcImportedFile;
 
     bool _bHighlightSamples;
     bool _bCursorValues;


### PR DESCRIPTION
This PR implements the feature requested in #156.

When a mbc file is imported, the file path is saved. When the import mbc dialog is opened again, the previous mbc file will be reloaded.