### PR TITLE
Don't set expression locale when no decimal separator is found

### DIFF
--- a/src/util/qmuparser.cpp
+++ b/src/util/qmuparser.cpp
@@ -43,8 +43,8 @@ void QMuParser::setExpression(QString expr)
         }
         else
         {
-            /* Default to comma */
-            _pExprParser->SetDecSep(',');
+            /* Keep current locale settings */
+            /* Locale settings are static (shared across all instances) */
         }
     }
 

--- a/tests/util/testqmuparser.cpp
+++ b/tests/util/testqmuparser.cpp
@@ -198,6 +198,20 @@ void TestQMuParser::evaluateDivByZero()
     QVERIFY(!bSuccess);
 }
 
+void TestQMuParser::evaluateDecimalSeparatorCombination()
+{
+    /* Test for #165 (locale is static) */
+    /* Bug was that last expression without decimal separator would set
+     * separator to default comma and let expression with point fail */
+    QMuParser parser_1("1.5");
+    QMuParser parser_2("5");
+
+    bool bSuccess = parser_1.evaluate();
+
+    QVERIFY(bSuccess);
+    QCOMPARE(parser_1.result(), 1.5);
+}
+
 void TestQMuParser::expressionGet()
 {
     QString expr = QStringLiteral("1.1 + 1,5");

--- a/tests/util/testqmuparser.h
+++ b/tests/util/testqmuparser.h
@@ -23,6 +23,7 @@ private slots:
     void evaluateInvalidBinExpr();
     void evaluateInvalidBinExpr_2();
 
+    void evaluateDecimalSeparatorCombination();
     void expressionGet();
     void expressionUpdate();
 


### PR DESCRIPTION
Closes #165