### PR TITLE
Handle constant expression correctly

### DIFF
--- a/src/communication/modbuspoll.cpp
+++ b/src/communication/modbuspoll.cpp
@@ -117,7 +117,7 @@ void ModbusPoll::handlePollDone(QMap<quint16, Result> partialResultMap, quint8 c
     }
 
     /* Last active modbus master has returned its result */
-    if (activeCnt == 1)
+    if (activeCnt == 1 || activeCnt == 0)
     {
         /* Last result */
         lastResult = true;
@@ -127,7 +127,10 @@ void ModbusPoll::handlePollDone(QMap<quint16, Result> partialResultMap, quint8 c
     _pRegisterValueHandler->processPartialResult(partialResultMap, connectionId);
 
     // Set master as inactive
-    _modbusMasters[connectionId]->bActive = false;
+    if (connectionId < Connection::ID_CNT)
+    {
+        _modbusMasters[connectionId]->bActive = false;
+    }
 
     if (lastResult)
     {
@@ -219,6 +222,12 @@ void ModbusPoll::triggerRegisterRead()
                 _modbusMasters[i]->bActive = true;
                 _modbusMasters[i]->pModbusMaster->readRegisterList(regAddrList.at(i));
             }
+        }
+
+        if (_activeMastersCount == 0)
+        {
+            QMap<quint16, Result> emptyResultMap;
+            handlePollDone(emptyResultMap, Connection::ID_1);
         }
     }
 }

--- a/tests/communication/testcommunication.cpp
+++ b/tests/communication/testcommunication.cpp
@@ -95,6 +95,20 @@ void TestCommunication::singleSlaveSuccess()
     CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList, valueList);
 }
 
+void TestCommunication::constantExpression()
+{
+    auto exprList = QStringList() << "3";
+    CommunicationHelpers::addExpressionsToModel(_pGraphDataModel, exprList);
+
+    auto resultList = QList<bool>() << true;
+    auto valueList = QList<double>() << 3;
+
+    QList<QVariant> rawRegData;
+    doHandleRegisterData(rawRegData);
+
+    CommunicationHelpers::verifyReceivedDataSignal(rawRegData, resultList, valueList);
+}
+
 void TestCommunication::mixed_1()
 {
     auto exprList = QStringList() << "${40002@2} + ${40003}"

--- a/tests/communication/testcommunication.h
+++ b/tests/communication/testcommunication.h
@@ -18,6 +18,7 @@ private slots:
     void cleanup();
 
     void singleSlaveSuccess();
+    void constantExpression();
 
     void mixed_1();
     void mixed_fail();

--- a/tests/communication/testmodbuspoll.cpp
+++ b/tests/communication/testmodbuspoll.cpp
@@ -122,6 +122,26 @@ void TestModbusPoll::singleSlaveFail()
     verifyReceivedDataSignal(arguments, expResults);
 }
 
+void TestModbusPoll::singleOnlyConstantDataPoll()
+{
+    ModbusPoll modbusPoll(_pSettingsModel);
+    QSignalSpy spyDataReady(&modbusPoll, &ModbusPoll::registerDataReady);
+
+    auto modbusRegisters = QList<ModbusRegister>(); /* No registers to poll */
+
+    /*-- Start communication --*/
+    modbusPoll.startCommunication(modbusRegisters);
+
+    QVERIFY(spyDataReady.wait(50));
+    QCOMPARE(spyDataReady.count(), 1);
+
+    QList<QVariant> arguments = spyDataReady.takeFirst();
+    auto expResults = QList<Result>();
+
+    /* Verify arguments of signal */
+    verifyReceivedDataSignal(arguments, expResults);
+}
+
 void TestModbusPoll::multiSlaveSuccess()
 {
     _testSlaveDataList[Connection::ID_1]->setRegisterState(0, true);

--- a/tests/communication/testmodbuspoll.h
+++ b/tests/communication/testmodbuspoll.h
@@ -18,6 +18,7 @@ private slots:
 
     void singleSlaveSuccess();
     void singleSlaveFail();
+    void singleOnlyConstantDataPoll();
 
     void multiSlaveSuccess();
     void multiSlaveSuccess_2();


### PR DESCRIPTION
When the expression is constant (eg "3"), the user would expect a log with data polls with value 3.