### PR TITLE
Improve expression dialog

### DIFF
--- a/src/communication/expressionparser.cpp
+++ b/src/communication/expressionparser.cpp
@@ -1,18 +1,16 @@
 #include "expressionparser.h"
 
 #include "scopelogging.h"
-
-const QString ExpressionParser::_cRegisterPattern = "\\${(\\d?.*?)}";
-const QString ExpressionParser::_cParseRegPattern = "(\\d+)(?:@(\\d+))?(?:\\:(\\w+))?";
+#include "expressionregex.h"
 
 const QString ExpressionParser::_cRegisterFunctionTemplate = "regval(%1)";
 
 ExpressionParser::ExpressionParser(QStringList& expressions)
 {
-    _findRegRegex.setPattern(_cRegisterPattern);
+    _findRegRegex.setPattern(ExpressionRegex::cMatchRegister);
     _findRegRegex.optimize();
 
-    _regParseRegex.setPattern(_cParseRegPattern);
+    _regParseRegex.setPattern(ExpressionRegex::cParseReg);
     _regParseRegex.optimize();
 
     parseExpressions(expressions);

--- a/src/communication/expressionparser.h
+++ b/src/communication/expressionparser.h
@@ -31,8 +31,6 @@ private:
     QRegularExpression _findRegRegex;
     QRegularExpression _regParseRegex;
 
-    static const QString _cRegisterPattern;
-    static const QString _cParseRegPattern;
     static const QString _cRegisterFunctionTemplate;
 
 };

--- a/src/communication/graphdatahandler.cpp
+++ b/src/communication/graphdatahandler.cpp
@@ -37,8 +37,6 @@ void GraphDataHandler::processActiveRegisters(GraphDataModel* pGraphDataModel)
 
     for(const QString &expr: qAsConst(processedExpList))
     {
-        /* Use pointer because our class otherwise needs copy/assignment constructor and such */
-        /* Remember to delete before removal */
         _valueParsers.append(QMuParser(expr));
     }
 }

--- a/src/dialogs/addregisterdialog.cpp
+++ b/src/dialogs/addregisterdialog.cpp
@@ -1,0 +1,103 @@
+#include "addregisterdialog.h"
+#include "settingsmodel.h"
+#include "updateregisternewexpression.h"
+
+#include "ui_addregisterdialog.h"
+
+AddRegisterDialog::AddRegisterDialog(SettingsModel* pSettingsModel, QWidget *parent) :
+    QDialog(parent),
+    _pUi(new Ui::AddRegisterDialog),
+    _pSettingsModel(pSettingsModel),
+    _graphData()
+{
+    _pUi->setupUi(this);
+
+    _pUi->lineName->setFocus();
+
+    /* Disable question mark button */
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    for (quint8 i = 0u; i < Connection::ID_CNT; i++)
+    {
+        if (_pSettingsModel->connectionState(i))
+        {
+            _pUi->cmbConnection->addItem(QString(tr("Connection %1").arg(i + 1)), i);
+        }
+    }
+
+
+    _bitGroup.setExclusive(true);
+    _bitGroup.addButton(_pUi->radio16Bit);
+    _bitGroup.addButton(_pUi->radio32Bit);
+
+    _signedGroup.setExclusive(true);
+    _signedGroup.addButton(_pUi->radioSigned);
+    _signedGroup.addButton(_pUi->radioUnsigned);
+}
+
+AddRegisterDialog::~AddRegisterDialog()
+{
+    delete _pUi;
+}
+
+GraphData AddRegisterDialog::graphData()
+{
+    return _graphData;
+}
+
+void AddRegisterDialog::done(int r)
+{
+    bool bValid = true;
+
+    if(QDialog::Accepted == r)  // ok was pressed
+    {
+        QString expression = generateExpression();
+
+        _graphData.setLabel(_pUi->lineName->text());
+        _graphData.setExpression(expression);
+
+        bValid = true;
+    }
+    else
+    {
+        // cancel, close or exc was pressed
+        bValid = true;
+    }
+
+    if (bValid)
+    {
+        QDialog::done(r);
+    }
+}
+
+QString AddRegisterDialog::generateExpression()
+{
+    quint32 registerAddress;
+    bool is32bit = false;
+    bool bUnsigned = true;
+    quint8 connectionId;
+
+    registerAddress = static_cast<quint32>(_pUi->spinAddress->value());
+
+    if (_pUi->radioSigned->isChecked())
+    {
+        bUnsigned = false;
+    }
+
+    if (_pUi->radio32Bit->isChecked())
+    {
+        is32bit = true;
+    }
+
+    QVariant data = _pUi->cmbConnection->currentData();
+    if (data.canConvert<quint8>())
+    {
+        connectionId = data.value<quint8>();
+    }
+    else
+    {
+        connectionId = 0;
+    }
+
+    return UpdateRegisterNewExpression::constructRegisterString(registerAddress, is32bit, bUnsigned, connectionId);
+}

--- a/src/dialogs/addregisterdialog.h
+++ b/src/dialogs/addregisterdialog.h
@@ -1,0 +1,38 @@
+#ifndef ADDREGISTERDIALOG_H
+#define ADDREGISTERDIALOG_H
+
+#include <QDialog>
+#include <QButtonGroup>
+#include "graphdata.h"
+
+class SettingsModel;
+
+namespace Ui {
+class AddRegisterDialog;
+}
+
+class AddRegisterDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit AddRegisterDialog(SettingsModel* pSettingsModel, QWidget *parent = nullptr);
+    ~AddRegisterDialog();
+
+    GraphData graphData();
+
+private:
+    void done(int r);
+    QString generateExpression();
+
+    Ui::AddRegisterDialog * _pUi;
+
+    SettingsModel* _pSettingsModel;
+
+    QButtonGroup _bitGroup;
+    QButtonGroup _signedGroup;
+
+    GraphData _graphData;
+};
+
+#endif // ADDREGISTERDIALOG_H

--- a/src/dialogs/addregisterdialog.ui
+++ b/src/dialogs/addregisterdialog.ui
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AddRegisterDialog</class>
+ <widget class="QDialog" name="AddRegisterDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>242</width>
+    <height>201</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add register</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0">
+   <item row="5" column="1">
+    <widget class="QRadioButton" name="radioSigned">
+     <property name="text">
+      <string>Signed</string>
+     </property>
+     <property name="autoExclusive">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="lineName">
+     <property name="text">
+      <string>Name of graph</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1">
+    <widget class="QRadioButton" name="radio32Bit">
+     <property name="text">
+      <string>32 bit</string>
+     </property>
+     <property name="autoExclusive">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QRadioButton" name="radioUnsigned">
+     <property name="text">
+      <string>Unsigned</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="autoExclusive">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QRadioButton" name="radio16Bit">
+     <property name="text">
+      <string>16 bit</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="autoExclusive">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QComboBox" name="cmbConnection"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QSpinBox" name="spinAddress">
+     <property name="maximum">
+      <number>105536</number>
+     </property>
+     <property name="value">
+      <number>40001</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>radio16Bit</tabstop>
+  <tabstop>radio32Bit</tabstop>
+  <tabstop>radioUnsigned</tabstop>
+  <tabstop>radioSigned</tabstop>
+  <tabstop>cmbConnection</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>AddRegisterDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>AddRegisterDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/dialogs/addregisterdialog.ui
+++ b/src/dialogs/addregisterdialog.ui
@@ -30,7 +30,7 @@
    <item row="1" column="0">
     <widget class="QLineEdit" name="lineName">
      <property name="text">
-      <string>Name of graph</string>
+      <string>Name of curve</string>
      </property>
     </widget>
    </item>

--- a/src/dialogs/expressionhighlighting.cpp
+++ b/src/dialogs/expressionhighlighting.cpp
@@ -1,0 +1,95 @@
+#include "expressionhighlighting.h"
+#include "expressionregex.h"
+
+#include <QDebug>
+
+ExpressionHighlighting::ExpressionHighlighting(QTextDocument *parent)
+        : QSyntaxHighlighter(parent)
+{
+
+    configureConstantNumberRules();
+    configureOperatorRules();
+    configureRegisterRules();
+}
+
+void ExpressionHighlighting::highlightBlock(const QString &text)
+{
+    for (const HighlightingRule &rule : qAsConst(_highlightingRules))
+    {
+        QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
+        while (matchIterator.hasNext())
+        {
+            QRegularExpressionMatch match = matchIterator.next();
+            setFormat(match.capturedStart(), match.capturedLength(), rule.format);
+        }
+    }
+
+    handleRegisterRules(text);
+}
+
+void ExpressionHighlighting::configureConstantNumberRules()
+{
+    HighlightingRule rule;
+
+    QTextCharFormat numberwordFormat;
+    numberwordFormat.setForeground(Qt::darkBlue);
+    numberwordFormat.setFontWeight(QFont::Bold);
+    const QString numberkeywordPatterns[] = {
+        ExpressionRegex::cNumberDec,
+        ExpressionRegex::cNumberBin,
+        ExpressionRegex::cNumberHex
+    };
+
+    for (const QString &pattern : numberkeywordPatterns)
+    {
+        rule.pattern = QRegularExpression(pattern);
+        rule.format = numberwordFormat;
+        _highlightingRules.append(rule);
+    }
+}
+
+void ExpressionHighlighting::configureOperatorRules()
+{
+    HighlightingRule rule;
+
+    QTextCharFormat keywordFormat;
+    keywordFormat.setForeground(Qt::gray);
+    keywordFormat.setFontWeight(QFont::Bold);
+    rule.pattern = QRegularExpression(ExpressionRegex::cOperatorcharacters);
+    rule.format = keywordFormat;
+    _highlightingRules.append(rule);
+}
+
+void ExpressionHighlighting::configureRegisterRules()
+{
+    _validRegFormat.setForeground(Qt::darkGreen);
+    _validRegFormat.setFontWeight(QFont::Bold);
+    _registerExpression = QRegularExpression(ExpressionRegex::cMatchRegister);
+
+    _invalidRegFormat.setForeground(Qt::darkRed);
+    _invalidRegFormat.setFontWeight(QFont::Bold);
+    _validRegisterExpression = QRegularExpression(ExpressionRegex::cParseReg);
+}
+
+void ExpressionHighlighting::handleRegisterRules(const QString &text)
+{
+    QRegularExpressionMatchIterator regMatchIterator = _registerExpression.globalMatch(text);
+    while (regMatchIterator.hasNext())
+    {
+        QRegularExpressionMatch regMatch = regMatchIterator.next();
+
+        QString matched= regMatch.captured();
+        QRegularExpressionMatch validRegMatch = _validRegisterExpression.match(matched);
+
+        QTextCharFormat format;
+        if (validRegMatch.hasMatch())
+        {
+            format = _validRegFormat;
+        }
+        else
+        {
+            format =  _invalidRegFormat;
+        }
+        setFormat(regMatch.capturedStart(), regMatch.capturedLength(), format);
+    }
+}

--- a/src/dialogs/expressionhighlighting.h
+++ b/src/dialogs/expressionhighlighting.h
@@ -1,0 +1,40 @@
+#ifndef EXPRESSIONHIGHLIGHTING_H
+#define EXPRESSIONHIGHLIGHTING_H
+
+#include <QSyntaxHighlighter>
+#include <QRegularExpression>
+
+class ExpressionHighlighting : public QSyntaxHighlighter
+{
+    Q_OBJECT
+
+public:
+    explicit ExpressionHighlighting(QTextDocument *parent = nullptr);
+
+protected:
+    void highlightBlock(const QString &text) override;
+
+private:
+    struct HighlightingRule
+    {
+        QRegularExpression pattern;
+        QTextCharFormat format;
+    };
+
+    void configureConstantNumberRules();
+    void configureOperatorRules();
+    void configureRegisterRules();
+
+    void handleRegisterRules(const QString &text);
+
+    QVector<HighlightingRule> _highlightingRules;
+
+    QRegularExpression _registerExpression;
+    QTextCharFormat _validRegFormat;
+
+    QRegularExpression _validRegisterExpression;
+    QTextCharFormat _invalidRegFormat;
+
+};
+
+#endif // EXPRESSIONHIGHLIGHTING_H

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -53,18 +53,29 @@ void ExpressionsDialog::handleExpressionChange()
     QList<ModbusRegister> registerList;
     _graphDataHandler.modbusRegisterList(registerList);
 
+    /* Save current test values */
+    QMap<QString, QString> _testValueMap;
+    for(qint32 idx = 0; idx < _pUi->tblExpressionInput->rowCount(); idx++)
+    {
+        QString descr = _pUi->tblExpressionInput->item(idx, 0)->text();
+        QString value = _pUi->tblExpressionInput->item(idx, 1)->text();
+
+        _testValueMap.insert(descr, value);
+    }
+
     _bUpdating = true;
     _pUi->tblExpressionInput->setRowCount(registerList.size());
 
     for(qint32 idx = 0; idx < registerList.size(); idx++)
     {
         ModbusRegister reg = registerList[idx];
-
-        QTableWidgetItem *newRegisterDescr = new QTableWidgetItem(reg.description());
+        QString regDescr = reg.description();
+        QTableWidgetItem *newRegisterDescr = new QTableWidgetItem(regDescr);
         newRegisterDescr->setFlags(newRegisterDescr->flags() & ~Qt::ItemIsEditable);
         _pUi->tblExpressionInput->setItem(idx, 0, newRegisterDescr);
 
-        QTableWidgetItem *newRegisterValue = new QTableWidgetItem("0");
+        QString testVal = _testValueMap.contains(regDescr) ? _testValueMap[regDescr]: "0";
+        QTableWidgetItem *newRegisterValue = new QTableWidgetItem(testVal);
         _pUi->tblExpressionInput->setItem(idx, 1, newRegisterValue);
     }
 

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -117,19 +117,36 @@ void ExpressionsDialog::handleAccept()
 void ExpressionsDialog::handleDataReady(QList<bool> successList, QList<double> values)
 {
     QString numOutput;
-    QString strTooltip;
+    QString strError;
 
-    if (successList.first())
+    bool const bOk = successList.first();
+
+    if (bOk)
     {
         numOutput = QString("%0").arg(values.first());
-        strTooltip = QString();
+        strError = QString();
     }
     else
     {
         numOutput = QStringLiteral("-");
-        strTooltip = _graphDataHandler.expressionParseMsg(0);
+        strError = _graphDataHandler.expressionParseMsg(0);
     }
 
     _pUi->lblOut->setText(numOutput);
-    _pUi->lblOut->setToolTip(strTooltip);
+    _pUi->lblOut->setToolTip(strError);
+
+    _pUi->lblError->setText(strError);
+    QString backgroundStyle;
+    if (bOk)
+    {
+        backgroundStyle = "background-color: rgba(0,0,0,0%);";
+    }
+    else
+    {
+        backgroundStyle = "background-color: rgba(255,0,0,50%);";
+    }
+
+    _pUi->lblOut->setStyleSheet(QString("border-style: outset;border-width: 1px; border-color: black; %1").arg(backgroundStyle));
+
+    _pUi->lblError->setStyleSheet(backgroundStyle);
 }

--- a/src/dialogs/expressionsdialog.cpp
+++ b/src/dialogs/expressionsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_expressionsdialog.h"
 
 #include "graphdatamodel.h"
+#include "expressionhighlighting.h"
 
 ExpressionsDialog::ExpressionsDialog(GraphDataModel *pGraphDataModel, qint32 idx, QWidget *parent) :
     QDialog(parent),
@@ -28,8 +29,10 @@ ExpressionsDialog::ExpressionsDialog(GraphDataModel *pGraphDataModel, qint32 idx
     connect(_pUi->btnCancel, &QPushButton::clicked, this, &ExpressionsDialog::handleCancel);
     connect(_pUi->btnAccept, &QPushButton::clicked, this, &ExpressionsDialog::handleAccept);
 
-    _pUi->lineExpression->setText(_pGraphDataModel->expression(_graphIdx));
-    connect(_pUi->lineExpression, &QLineEdit::textChanged, this, &ExpressionsDialog::handleExpressionChange);
+    _pHighlighter = new ExpressionHighlighting(_pUi->lineExpression->document());
+
+    _pUi->lineExpression->setPlainText(_pGraphDataModel->expression(_graphIdx));
+    connect(_pUi->lineExpression, &QPlainTextEdit::textChanged, this, &ExpressionsDialog::handleExpressionChange);
 
     handleExpressionChange();
 }
@@ -43,7 +46,7 @@ void ExpressionsDialog::handleExpressionChange()
 {
     _localGraphDataModel.clear();
     _localGraphDataModel.add();
-    _localGraphDataModel.setExpression(0, _pUi->lineExpression->text());
+    _localGraphDataModel.setExpression(0, _pUi->lineExpression->toPlainText());
 
     _graphDataHandler.processActiveRegisters(&_localGraphDataModel);
 
@@ -106,7 +109,7 @@ void ExpressionsDialog::handleCancel()
 
 void ExpressionsDialog::handleAccept()
 {
-    _pGraphDataModel->setExpression(_graphIdx, _pUi->lineExpression->text());
+    _pGraphDataModel->setExpression(_graphIdx, _pUi->lineExpression->toPlainText());
 
     done(QDialog::Accepted);
 }

--- a/src/dialogs/expressionsdialog.h
+++ b/src/dialogs/expressionsdialog.h
@@ -5,6 +5,9 @@
 #include "graphdatahandler.h"
 #include "graphdatamodel.h"
 
+/* Forward declaration */
+class ExpressionHighlighting;
+
 namespace Ui {
 class ExpressionsDialog;
 }
@@ -31,9 +34,10 @@ private:
     qint32 _graphIdx;
 
     GraphDataModel* _pGraphDataModel;
-
     GraphDataModel _localGraphDataModel;
     GraphDataHandler _graphDataHandler;
+
+    ExpressionHighlighting *_pHighlighter;
 
     bool _bUpdating;
 };

--- a/src/dialogs/expressionsdialog.ui
+++ b/src/dialogs/expressionsdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>823</width>
-    <height>628</height>
+    <height>819</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,10 +39,7 @@
           <string>Compose Expression</string>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="1,0">
-          <item row="5" column="0">
-           <widget class="QTableWidget" name="tblExpressionInput"/>
-          </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <widget class="QLabel" name="lblOut">
@@ -54,6 +51,9 @@
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
+              </property>
+              <property name="margin">
+               <number>5</number>
               </property>
              </widget>
             </item>
@@ -72,17 +72,35 @@
             </item>
            </layout>
           </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Processed Output</string>
+          <item row="2" column="0" colspan="2">
+           <widget class="QPlainTextEdit" name="lineExpression">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="inputMethodHints">
+             <set>Qt::ImhNone</set>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="tabChangesFocus">
+             <bool>true</bool>
+            </property>
+            <property name="lineWrapMode">
+             <enum>QPlainTextEdit::NoWrap</enum>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Example Input</string>
+          <item row="6" column="0">
+           <widget class="QTableWidget" name="tblExpressionInput">
+            <property name="selectionMode">
+             <enum>QAbstractItemView::NoSelection</enum>
             </property>
            </widget>
           </item>
@@ -96,8 +114,29 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QPlainTextEdit" name="lineExpression"/>
+          <item row="4" column="1">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Processed Output</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Example Input</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="lblError">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="margin">
+             <number>5</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/dialogs/expressionsdialog.ui
+++ b/src/dialogs/expressionsdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>823</width>
-    <height>651</height>
+    <height>628</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,6 +39,9 @@
           <string>Compose Expression</string>
          </property>
          <layout class="QGridLayout" name="gridLayout" columnstretch="1,0">
+          <item row="5" column="0">
+           <widget class="QTableWidget" name="tblExpressionInput"/>
+          </item>
           <item row="5" column="1">
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
@@ -69,34 +72,6 @@
             </item>
            </layout>
           </item>
-          <item row="5" column="0">
-           <widget class="QTableWidget" name="tblExpressionInput"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLineEdit" name="lineExpression">
-            <property name="font">
-             <font>
-              <family>Ubuntu Mono</family>
-             </font>
-            </property>
-            <property name="text">
-             <string>VAL</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Expression</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="buddy">
-             <cstring>lineExpression</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="1">
            <widget class="QLabel" name="label_6">
             <property name="text">
@@ -110,6 +85,19 @@
              <string>Example Input</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Expression</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QPlainTextEdit" name="lineExpression"/>
           </item>
          </layout>
         </widget>

--- a/src/dialogs/expressionsdialog.ui
+++ b/src/dialogs/expressionsdialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>823</width>
-    <height>819</height>
+    <height>829</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,7 +38,7 @@
          <property name="title">
           <string>Compose Expression</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout" columnstretch="1,0">
+         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,1,0,0,0,1" columnstretch="1,0">
           <item row="6" column="1">
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
@@ -104,6 +104,13 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Processed Output</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
@@ -114,10 +121,10 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QLabel" name="label_6">
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="lblError">
             <property name="text">
-             <string>Processed Output</string>
+             <string>TextLabel</string>
             </property>
            </widget>
           </item>
@@ -125,16 +132,6 @@
            <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Example Input</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="lblError">
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-            <property name="margin">
-             <number>5</number>
             </property>
            </widget>
           </item>

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -422,7 +422,7 @@ void MainWindow::showRegisterDialog(QString mbcFile)
         _pGuiModel->setGuiState(GuiModel::INIT);
     }
 
-    RegisterDialog registerDialog(_pGuiModel, _pGraphDataModel, this);
+    RegisterDialog registerDialog(_pGuiModel, _pGraphDataModel, _pSettingsModel, this);
 
     if (mbcFile.isEmpty())
     {

--- a/src/dialogs/registerdialog.cpp
+++ b/src/dialogs/registerdialog.cpp
@@ -4,10 +4,15 @@
 #include "registerdialog.h"
 #include "importmbcdialog.h"
 #include "expressionsdialog.h"
+#include "addregisterdialog.h"
+
+#include "graphdatamodel.h"
+#include "guimodel.h"
+#include "settingsmodel.h"
 
 #include "ui_registerdialog.h"
 
-RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataModel, QWidget *parent) :
+RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataModel, SettingsModel *pSettingsModel, QWidget *parent) :
     QDialog(parent),
     _pUi(new Ui::RegisterDialog)
 {
@@ -18,6 +23,7 @@ RegisterDialog::RegisterDialog(GuiModel *pGuiModel, GraphDataModel * pGraphDataM
 
     _pGraphDataModel = pGraphDataModel;
     _pGuiModel = pGuiModel;
+    _pSettingsModel = pSettingsModel;
 
     // Setup registerView
     _pUi->registerView->setModel(_pGraphDataModel);
@@ -62,7 +68,12 @@ int RegisterDialog::execWithMbcImport()
 
 void RegisterDialog::addRegisterRow()
 {
-    _pGraphDataModel->insertRow(_pGraphDataModel->size());
+    AddRegisterDialog addRegisterDialog(_pSettingsModel);
+
+    if (addRegisterDialog.exec() == QDialog::Accepted)
+    {
+        _pGraphDataModel->add(addRegisterDialog.graphData());
+    }
 }
 
 void RegisterDialog::showImportDialog()

--- a/src/dialogs/registerdialog.h
+++ b/src/dialogs/registerdialog.h
@@ -3,8 +3,10 @@
 
 #include <QDialog>
 
-#include "graphdatamodel.h"
-#include "guimodel.h"
+/* Forward declaration */
+class GraphDataModel;
+class GuiModel;
+class SettingsModel;
 
 namespace Ui {
 class RegisterDialog;
@@ -15,7 +17,7 @@ class RegisterDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit RegisterDialog(GuiModel * pGuiModel, GraphDataModel *pGraphDataModel, QWidget *parent = nullptr);
+    explicit RegisterDialog(GuiModel * pGuiModel, GraphDataModel *pGraphDataModel, SettingsModel* pSettingsModel, QWidget *parent = nullptr);
     ~RegisterDialog();
 
 public slots:
@@ -32,10 +34,12 @@ private:
     int selectedRowAfterDelete(int deletedStartIndex, int rowCnt);
     static bool sortRegistersLastFirst(const QModelIndex &s1, const QModelIndex &s2);
 
-    Ui::RegisterDialog * _pUi;
+    Ui::RegisterDialog* _pUi;
 
-    GraphDataModel * _pGraphDataModel;
-    GuiModel * _pGuiModel;
+    GraphDataModel* _pGraphDataModel;
+    GuiModel* _pGuiModel;
+    SettingsModel* _pSettingsModel;
+
 };
 
 #endif // REGISTERDIALOG_H

--- a/src/importexport/datafileexporter.cpp
+++ b/src/importexport/datafileexporter.cpp
@@ -433,7 +433,7 @@ QString DataFileExporter::createPropertyRow(registerProperty prop)
             break;
 
         case E_EXPRESSION:
-            propertyString = QString("\"%1\"").arg(_pGraphDataModel->expression(graphIdx));
+            propertyString = QString("\"%1\"").arg(_pGraphDataModel->expression(graphIdx).simplified());
             break;
 
         default:

--- a/src/importexport/updateregisternewexpression.cpp
+++ b/src/importexport/updateregisternewexpression.cpp
@@ -2,7 +2,6 @@
 #include "updateregisternewexpression.h"
 
 #include <QStringLiteral>
-#include <stdlib.h>
 
 namespace UpdateRegisterNewExpression
 {

--- a/src/util/expressionregex.cpp
+++ b/src/util/expressionregex.cpp
@@ -1,0 +1,16 @@
+#include "expressionregex.h"
+
+
+const QString ExpressionRegex::cOperatorcharacters = "[\\+\\-\\*\\^\\/\\?\\<\\>\\=\\!\\%\\&\\|\\~\\'\\_]";
+
+const QString ExpressionRegex::cNumberDec = "\\d+";
+const QString ExpressionRegex::cNumberHex = "0[x]\\d+";
+const QString ExpressionRegex::cNumberBin = "0[b]\\d+";
+
+const QString ExpressionRegex::cMatchRegister = "\\$\\{(\\d?.*?)\\}";
+const QString ExpressionRegex::cParseReg = "\\$\\{\\s*(\\d+)(?:\\s*@\\s*(\\d+))?(?:\\s*\\:\\s*(\\w+))?\\s*\\}";
+
+ExpressionRegex::ExpressionRegex()
+{
+
+}

--- a/src/util/expressionregex.h
+++ b/src/util/expressionregex.h
@@ -1,0 +1,25 @@
+#ifndef EXPRESSIONREGEX_H
+#define EXPRESSIONREGEX_H
+
+#include <QRegularExpression>
+
+class ExpressionRegex
+{
+public:
+    ExpressionRegex();
+
+    static const QString cOperatorcharacters;
+    static const QString cNumberDec;
+    static const QString cNumberHex;
+    static const QString cNumberBin;
+
+    static const QString cMatchRegister;
+    static const QString cParseReg;
+
+private:
+
+
+
+};
+
+#endif // EXPRESSIONREGEX_H

--- a/src/util/muparserregister.cpp
+++ b/src/util/muparserregister.cpp
@@ -73,7 +73,7 @@ namespace mu
             }
             else
             {
-                throw exception_type(_T("Communication error"));
+                throw exception_type(_T("Invalid data error"));
             }
         }
         else


### PR DESCRIPTION
Improve expression dialog to make it more user friendly (syntax highlighting of expression, error messages, ...)

- [ ] Keep test values when expression is updated.
- [x] Rename `register` and `graph` to curve(, line or plot)
- [x] Remove newline when exporting data