### PR TITLE
Let DFetch monitor dependencies in a github action

### DIFF
--- a/.github/workflows/dfetch.yml
+++ b/.github/workflows/dfetch.yml
@@ -1,0 +1,28 @@
+name: DFetch
+
+on: push
+
+jobs:
+  dfetch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Set up dfetch
+      run: |
+         python -m pip install --upgrade pip
+         pip install dfetch
+
+    - name: Check dependencies
+      run: dfetch check --sarif sarif.json
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: sarif.json

--- a/.github/workflows/dfetch.yml
+++ b/.github/workflows/dfetch.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up dfetch
       run: |
          python -m pip install --upgrade pip
-         pip install dfetch
+         pip install https://github.com/dfetch-org/dfetch/archive/main.zip
 
     - name: Check dependencies
       run: dfetch check --sarif sarif.json


### PR DESCRIPTION
This pull request lets dfetch check your dependencies in your manifest.
See [Sarif reporter](https://dfetch.readthedocs.io/en/latest/manual.html#module-dfetch.reporting.check.sarif_reporter) for more information and screenshots.