### PR TITLE
Allow scrolling to negative times when there is negative time data

### DIFF
--- a/data/data_all_unsigned.csv
+++ b/data/data_all_unsigned.csv
@@ -1,0 +1,17 @@
+//ModbusScope version;0.7.4
+//Start time;24-06-2015 22:24:38
+//End time;24-06-2015 22:24:43
+//Slave IP;127.0.0.1:502
+//Slave ID;1
+//Time-out;1000
+//Poll interval;1000
+//Communication success;5
+//Communication errors;0
+//
+Time (ms);Register 40001;Register 40002;Register 40003
+-4024;2;4;6
+-3025;0;0;0
+-2025;10;20;30
+-1024;8;16;24
+-25;6;12;18
+

--- a/data/data_unsigned.csv
+++ b/data/data_unsigned.csv
@@ -1,0 +1,21 @@
+//ModbusScope version;0.7.4
+//Start time;24-06-2015 22:24:38
+//End time;24-06-2015 22:24:43
+//Slave IP;127.0.0.1:502
+//Slave ID;1
+//Time-out;1000
+//Poll interval;1000
+//Communication success;5
+//Communication errors;0
+//
+Time (ms);Register 40001;Register 40002;Register 40003
+-4024;2;4;6
+-3025;0;0;0
+-2025;10;20;30
+-1024;8;16;24
+-25;6;12;18
+25;6;12;18
+1024;8;16;24
+2025;10;20;30
+3025;0;0;0
+4024;2;4;6

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -785,18 +785,25 @@ void GraphView::xAxisRangeChanged(const QCPRange &newRange, const QCPRange &oldR
 {
     QCPRange range = newRange;
 
-    if (newRange.upper <= 0)
+    const double beginKey = _pGraphDataModel->dataMap(0)->constBegin()->key;
+    if (range.lower < 0)
     {
-        range.upper = oldRange.upper;
+        if (beginKey > 0)
+        {
+            range.lower = 0;
+        }
+        else
+        {
+            range.lower = range.lower < beginKey ? beginKey: range.lower;
+        }
     }
 
-    if (newRange.lower <= 0)
+    if (range.upper < range.lower)
     {
-        range.lower = 0;
+        range.upper = range.lower;
     }
 
     _pPlot->xAxis->setRange(range);
-
 
     updateTooltip();
 }


### PR DESCRIPTION
Scrolling to negative time is allowed when negative time data is present. Main use case a oscilloscope data

Fixes #198 