### PR TITLE
Revert to Qt5 to fix blurry tick labels

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,10 +4,14 @@ name: Build
 on: push
 
 jobs:
-
   linux:
     runs-on: ubuntu-20.04
-    container: docker://jgeudens/qt-linux:6.2.2_build_1
+    strategy:
+      matrix:
+        container: ["5.15.2_build_2", "6.2.2_build_1"]
+
+    container:
+      image: docker://jgeudens/qt-linux:${{ matrix.container }}
     steps:
       - uses: actions/checkout@v2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 COMPONENTS
+# Find the QtCore library
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+
+message(STATUS "Using Qt${QT_VERSION_MAJOR} version ${Qt${QT_VERSION_MAJOR}Core_VERSION}")
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
     Widgets
     Xml
     Network

--- a/libraries/qcustomplot/CMakeLists.txt
+++ b/libraries/qcustomplot/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
     Widgets
     PrintSupport
 

--- a/scripts/setup_windows.bat
+++ b/scripts/setup_windows.bat
@@ -4,19 +4,19 @@ if "%~1"=="" (set "QT_INSTALL_DIR=D:\aqt_Qt\Qt") else (set "QT_INSTALL_DIR=%~1\Q
 echo QT_INSTALL_DIR: %QT_INSTALL_DIR%
 
 REM Set configuration
-set QT=6.2.2
-set QT_MODULES=qtserialbus qtserialport
+set QT=5.15.2
+set QT_MODULES=
 set QT_HOST=windows
 set QT_TARGET=desktop
-set QT_ARCH=win64_mingw
+set QT_ARCH=win64_mingw81
 
-set QT_ARCH_PATH=mingw_64
+set QT_ARCH_PATH=mingw81_64
 
 REM Install Qt
 aqt install-qt --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% %QT% %QT_ARCH%  -m %QT_MODULES%
 
 REM Install Tools
-aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw90 qt.tools.win64_mingw900
+aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw qt.tools.win64_mingw810
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_cmake
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_ninja
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_openssl_x64
@@ -27,13 +27,13 @@ dir %QT_INSTALL_DIR%\Tools
 
 REM Set env variables with path
 set "PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\bin;%PATH%"
-set "PATH=%QT_INSTALL_DIR%\Tools\mingw1120_64\bin;%PATH%"
+set "PATH=%QT_INSTALL_DIR%\Tools\mingw810_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\CMake_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\Ninja;%PATH%"
 
 set "QT_PLUGIN_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\plugins\"
 set "QML_IMPORT_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\qml\"
 set "QML2_IMPORT_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\qml\"
-set "CMAKE_PREFIX_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\lib\cmake\Qt6"
+set "CMAKE_PREFIX_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\lib\cmake\Qt5"
 
 set "OPENSSL_DIR=%QT_INSTALL_DIR%\Tools\OpenSSL\Win_x64\bin"

--- a/src/communication/modbusconnection.cpp
+++ b/src/communication/modbusconnection.cpp
@@ -2,7 +2,11 @@
 #include <QVariant>
 #include <QtSerialPort/QSerialPort>
 #include <QModbusTcpClient>
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
 #include <QModbusRtuSerialClient>
+#else
+#include <QModbusRtuSerialMaster>
+#endif
 
 #include "scopelogging.h"
 #include "modbusconnection.h"
@@ -46,7 +50,12 @@ void ModbusConnection::openSerialConnection(struct SerialSettings serialSettings
 {
     if (prepareConnectionOpen())
     {
-        auto connectionData = QPointer<ConnectionData>(new ConnectionData(new QModbusRtuSerialClient()));
+#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
+        QModbusRtuSerialClient* pClient = new QModbusRtuSerialClient();
+#else
+        QModbusRtuSerialMaster* pClient = new QModbusRtuSerialMaster();
+#endif
+        auto connectionData = QPointer<ConnectionData>(new ConnectionData(pClient));
 
         connectionData->pModbusClient->setConnectionParameter(QModbusDevice::SerialPortNameParameter, QVariant(serialSettings.portName));
         connectionData->pModbusClient->setConnectionParameter(QModbusDevice::SerialParityParameter, QVariant(serialSettings.parity));

--- a/src/importexport/settingsauto.cpp
+++ b/src/importexport/settingsauto.cpp
@@ -57,17 +57,17 @@ bool SettingsAuto::updateSettings(QTextStream* pDataFileStream, settingsData_t *
 
         // First try French locale
         bool bParse;
-        bParse = testLocale(previewData, frLocale, ';');
+        bParse = testLocale(previewData, frLocale, QString(';'));
 
         if (!bParse)
         {
             // Else try Italian locale
-            bParse = testLocale(previewData, itLocale, ';');
+            bParse = testLocale(previewData, itLocale, QString(';'));
 
             if (!bParse)
             {
                 // Else try US English locale
-                bRet = testLocale(previewData, enLocale, ',');
+                bRet = testLocale(previewData, enLocale, QString(','));
             }
         }
     }
@@ -160,7 +160,7 @@ bool SettingsAuto::isComment(QString line)
     return bRet;
 }
 
-bool SettingsAuto::testLocale(QStringList previewData, QLocale locale, QChar fieldSeparator)
+bool SettingsAuto::testLocale(QStringList previewData, QLocale locale, QString fieldSeparator)
 {
     quint32 aSeparatorCount[2];
     aSeparatorCount[0] = previewData[_labelRow].count(fieldSeparator);
@@ -220,23 +220,23 @@ bool SettingsAuto::testLocale(QStringList previewData, QLocale locale, QChar fie
     }
 
     _fieldSeparator = fieldSeparator;
-    _decimalSeparator = locale.decimalPoint().at(0);
+    _decimalSeparator = QString(locale.decimalPoint());
 
     // In US locale field separator is the same as group (thousands) point
-    if (fieldSeparator == locale.groupSeparator())
+    if (fieldSeparator == QString(locale.groupSeparator()))
     {
         _groupSeparator = ' ';
     }
     else if (
-             (locale.groupSeparator().at(0) == QChar(0xA0)) // no-break space
-             || (locale.groupSeparator().at(0) == QChar(0x202F)) //narrow no-break space
+             (QString(locale.groupSeparator()) == QString(QChar(0xA0))) // no-break space
+             || (QString(locale.groupSeparator()) == QString(QChar(0x202F))) //narrow no-break space
         )
     {
         _groupSeparator = ' ';
     }
     else
     {
-       _groupSeparator = locale.groupSeparator().at(0);
+        _groupSeparator = QString(locale.groupSeparator());
     }
 
     return true;

--- a/src/importexport/settingsauto.h
+++ b/src/importexport/settingsauto.h
@@ -16,9 +16,9 @@ public:
     typedef struct
     {
         bool bModbusScopeDataFile;
-        QChar fieldSeparator;
-        QChar groupSeparator;
-        QChar decimalSeparator;
+        QString fieldSeparator;
+        QString groupSeparator;
+        QString decimalSeparator;
         QString commentSequence;
         quint32 dataRow;
         quint32 column;
@@ -39,13 +39,13 @@ private:
     bool isAbsoluteDate(QString rawData);
     bool isModbusScopeDataFile(QString firstLine);
     bool isComment(QString line);
-    bool testLocale(QStringList previewData, QLocale locale, QChar fieldSeparator);
+    bool testLocale(QStringList previewData, QLocale locale, QString fieldSeparator);
     quint32 nextDataLine(quint32 startIdx, QStringList previewData, bool *bOk);
 
     bool _bModbusScopeDataFile;
-    QChar _fieldSeparator;
-    QChar _groupSeparator;
-    QChar _decimalSeparator;
+    QString _fieldSeparator;
+    QString _groupSeparator;
+    QString _decimalSeparator;
     QString _commentSequence;
     quint32 _dataRow;
     quint32 _column;

--- a/src/models/dataparsermodel.cpp
+++ b/src/models/dataparsermodel.cpp
@@ -15,7 +15,7 @@ DataParserModel::~DataParserModel()
 void DataParserModel::resetSettings()
 {
     /*-- Set default item --*/
-    const QChar decimalPoint = QLocale().decimalPoint().at(0);
+    const QString decimalPoint = QString(QLocale().decimalPoint());
 
     // DecimalSeparator
     if (decimalPoint == '.')
@@ -37,7 +37,7 @@ void DataParserModel::resetSettings()
         _fieldSeparator = ',';
     }
 
-    _groupSeparator = QLocale().groupSeparator().at(0);
+    _groupSeparator = QLocale().groupSeparator();
     _commentSequence = "";
     _dataRow = 1;
     _column = 0;
@@ -61,7 +61,7 @@ void DataParserModel::triggerUpdate(void)
     emit dataFilePathChanged();
 }
 
-void DataParserModel::setFieldSeparator(QChar fieldSeparator)
+void DataParserModel::setFieldSeparator(QString fieldSeparator)
 {
     // Exception to the rule, always generate event when field separator is changed
     // This is needed for these custom field separator
@@ -72,7 +72,7 @@ void DataParserModel::setFieldSeparator(QChar fieldSeparator)
     }
 }
 
-void DataParserModel::setGroupSeparator(QChar groupSeparator)
+void DataParserModel::setGroupSeparator(QString groupSeparator)
 {
     if (_groupSeparator != groupSeparator)
     {
@@ -81,7 +81,7 @@ void DataParserModel::setGroupSeparator(QChar groupSeparator)
     }
 }
 
-void DataParserModel::setDecimalSeparator(QChar decimalSeparator)
+void DataParserModel::setDecimalSeparator(QString decimalSeparator)
 {
     if (_decimalSeparator != decimalSeparator)
     {
@@ -153,17 +153,17 @@ void DataParserModel::setDataFilePath(QString path)
     }
 }
 
-QChar DataParserModel::fieldSeparator() const
+QString DataParserModel::fieldSeparator() const
 {
     return _fieldSeparator;
 }
 
-QChar DataParserModel::groupSeparator() const
+QString DataParserModel::groupSeparator() const
 {
     return _groupSeparator;
 }
 
-QChar DataParserModel::decimalSeparator() const
+QString DataParserModel::decimalSeparator() const
 {
     return _decimalSeparator;
 }

--- a/src/models/dataparsermodel.h
+++ b/src/models/dataparsermodel.h
@@ -13,9 +13,9 @@ public:
     void triggerUpdate(void);
     void resetSettings();
 
-    QChar fieldSeparator() const;
-    QChar groupSeparator() const;
-    QChar decimalSeparator() const;
+    QString fieldSeparator() const;
+    QString groupSeparator() const;
+    QString decimalSeparator() const;
     QString commentSequence() const;
     quint32 dataRow() const;
     quint32 column() const;
@@ -24,9 +24,9 @@ public:
     bool stmStudioCorrection() const;
     QString dataFilePath();
     
-    void setFieldSeparator(QChar fieldSeparator);
-    void setGroupSeparator(QChar groupSeparator);
-    void setDecimalSeparator(QChar decimalSeparator);
+    void setFieldSeparator(QString fieldSeparator);
+    void setGroupSeparator(QString groupSeparator);
+    void setDecimalSeparator(QString decimalSeparator);
     void setCommentSequence(QString commentSequence);
     void setDataRow(quint32 dataRow);
     void setColumn(quint32 column);
@@ -49,9 +49,9 @@ signals:
 
 private:
 
-    QChar _fieldSeparator;
-    QChar _groupSeparator;
-    QChar _decimalSeparator;
+    QString _fieldSeparator;
+    QString _groupSeparator;
+    QString _decimalSeparator;
     QString _commentSequence;
     quint32 _dataRow;
     quint32 _column;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ set(
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/gmockutils.cpp
 )
 
-find_package(Qt6 COMPONENTS
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS
     Test
     REQUIRED
 )


### PR DESCRIPTION
Revert official windows release back to Qt 5.15.2.

Code is made compatible with both. Build for Linux is done with both Qt5.15 and Qt6