### PR TITLE
Qt6 blurry tick

### DIFF
--- a/scripts/setup_windows.bat
+++ b/scripts/setup_windows.bat
@@ -4,19 +4,19 @@ if "%~1"=="" (set "QT_INSTALL_DIR=D:\aqt_Qt\Qt") else (set "QT_INSTALL_DIR=%~1\Q
 echo QT_INSTALL_DIR: %QT_INSTALL_DIR%
 
 REM Set configuration
-set QT=5.15.2
-set QT_MODULES=
+set QT=6.2.2
+set QT_MODULES=qtserialbus qtserialport
 set QT_HOST=windows
 set QT_TARGET=desktop
-set QT_ARCH=win64_mingw81
+set QT_ARCH=win64_mingw
 
-set QT_ARCH_PATH=mingw81_64
+set QT_ARCH_PATH=mingw_64
 
 REM Install Qt
 aqt install-qt --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% %QT% %QT_ARCH%  -m %QT_MODULES%
 
 REM Install Tools
-aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw qt.tools.win64_mingw810
+aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_mingw90 qt.tools.win64_mingw900
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_cmake
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_ninja
 aqt install-tool --outputdir %QT_INSTALL_DIR% %QT_HOST% %QT_TARGET% tools_openssl_x64
@@ -27,13 +27,13 @@ dir %QT_INSTALL_DIR%\Tools
 
 REM Set env variables with path
 set "PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\bin;%PATH%"
-set "PATH=%QT_INSTALL_DIR%\Tools\mingw810_64\bin;%PATH%"
+set "PATH=%QT_INSTALL_DIR%\Tools\mingw1120_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\CMake_64\bin;%PATH%"
 set "PATH=%QT_INSTALL_DIR%\Tools\Ninja;%PATH%"
 
 set "QT_PLUGIN_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\plugins\"
 set "QML_IMPORT_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\qml\"
 set "QML2_IMPORT_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\qml\"
-set "CMAKE_PREFIX_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\lib\cmake\Qt5"
+set "CMAKE_PREFIX_PATH=%QT_INSTALL_DIR%\%QT%\%QT_ARCH_PATH%\lib\cmake\Qt6"
 
 set "OPENSSL_DIR=%QT_INSTALL_DIR%\Tools\OpenSSL\Win_x64\bin"

--- a/src/dialogs/mainwindow.cpp
+++ b/src/dialogs/mainwindow.cpp
@@ -172,6 +172,9 @@ MainWindow::MainWindow(QStringList cmdArguments, GuiModel* pGuiModel,
 
     this->setAcceptDrops(true);
 
+    this->winId(); // Ensures the native window has been created.
+    connect(this->windowHandle(), &QWindow::screenChanged, _pGraphView, &GraphView::screenChanged);
+
     // For dock undock
     connect(_pUi->scaleOptionsDock, &QDockWidget::topLevelChanged, this, &MainWindow::scaleWidgetUndocked);
     connect(_pUi->legendDock, &QDockWidget::topLevelChanged, this, &MainWindow::legendWidgetUndocked);
@@ -1066,6 +1069,7 @@ void MainWindow::updateDataFileNotes()
         }
     }
 }
+
 void MainWindow::showVersionUpdate(UpdateNotify::UpdateState result)
 {
     if (result == UpdateNotify::VERSION_LATEST)

--- a/src/graphview/graphview.cpp
+++ b/src/graphview/graphview.cpp
@@ -53,6 +53,8 @@ GraphView::GraphView(GuiModel * pGuiModel, SettingsModel *pSettingsModel, GraphD
     _pGraphMarkers = new GraphMarkers(_pGuiModel, _pPlot, this);
     _pNoteHandling = new NoteHandling(pNoteModel, _pPlot, this);
 
+    screenChanged(_pPlot->screen());
+
     _pPlot->replot();
 }
 
@@ -333,6 +335,14 @@ void GraphView::clearResults()
     _pGuiModel->setyAxisScale(AxisMode::SCALE_AUTO);
 
    rescalePlot();
+}
+
+void GraphView::screenChanged(QScreen *screen)
+{
+    /* https://phabricator.kde.org/D20171 */
+    _pPlot->setBufferDevicePixelRatio(screen->devicePixelRatio());
+
+    _pPlot->replot();
 }
 
 void GraphView::showMarkers()

--- a/src/graphview/graphview.h
+++ b/src/graphview/graphview.h
@@ -45,6 +45,7 @@ public slots:
     void rescalePlot();
     void plotResults(QList<bool> successList, QList<double> valueList);
     void clearResults();
+    void screenChanged(QScreen *screen);
 
 signals:
     void cursorValueUpdate();


### PR DESCRIPTION
* Improve screen scaling better by updating the device pixel ratio handling when windows is moved to other screen
  * https://phabricator.kde.org/D20171
* Fix incorrect scaling by updating the pixel ratio at startup. Initial call in QCustomPlot apparently returns incorrect value.
* Change Windows back build to Qt6