### PR TITLE
Improve csv import

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -7,6 +7,7 @@ The latest *ModbusScope* installer or standalone version can always be downloade
 ### Changed
 
 *  When starting only set scaling to auto when it is set to manual ([Github #210](https://github.com/jgeudens/ModbusScope/issues/210))
+*  Improve import/export of csv data (especially when modifying file in Excel) ([Github #220](https://github.com/jgeudens/ModbusScope/issues/220))
 
 ### Added
 

--- a/src/importexport/datafileexporter.cpp
+++ b/src/importexport/datafileexporter.cpp
@@ -196,8 +196,17 @@ bool DataFileExporter::updateNoteLines(QString dataFile)
             }
 
             // Add notes
-            tmpStream << createNoteRows();
-            tmpStream << "//\n";
+            QStringList noteRows;
+            createNoteRows(noteRows);
+            if (!noteRows.isEmpty())
+            {
+                for(const QString &noteRow: qAsConst(noteRows))
+                {
+                    tmpStream << noteRow << "\n";
+                }
+
+                tmpStream << "//\n";
+            }
 
             // Copy last line
             tmpStream << line << "\n";
@@ -322,9 +331,13 @@ QStringList DataFileExporter::constructDataHeader(bool bDuringLog)
 
         header.append("//");
 
-        header.append(createNoteRows());
-
-        header.append("//");
+        QStringList noteRows;
+        createNoteRows(noteRows);
+        if (!noteRows.isEmpty())
+        {
+            header.append(noteRows);
+            header.append("//");
+        }
     }
 
     return header;
@@ -364,10 +377,8 @@ QString DataFileExporter::constructConnSettings(quint8 connectionId)
                           .arg(strSettings);
 }
 
-QString DataFileExporter::createNoteRows(void)
+void DataFileExporter::createNoteRows(QStringList& noteRows)
 {
-    QString noteRows;
-
     for (qint32 idx = 0; idx < _pNoteModel->size(); idx++)
     {
         QString noteline;
@@ -385,12 +396,8 @@ QString DataFileExporter::createNoteRows(void)
 
         noteline.append(Util::separatorCharacter() + '"' + _pNoteModel->textData(idx) + '"');
 
-        noteline.append("\n");
-
         noteRows.append(noteline);
     }
-
-    return noteRows;
 }
 
 QString DataFileExporter::createPropertyRow(registerProperty prop)

--- a/src/importexport/datafileexporter.h
+++ b/src/importexport/datafileexporter.h
@@ -45,7 +45,7 @@ private:
     void exportDataHeader();
     QStringList constructDataHeader(bool bDuringLog);
     QString constructConnSettings(quint8 connectionId);
-    QString createNoteRows();
+    void createNoteRows(QStringList& noteRows);
     QString createPropertyRow(registerProperty prop);
     QString formatData(double timeData, QList<double> dataValues);
     bool writeToFile(QString filePath, QStringList logData);

--- a/src/importexport/datafileparser.cpp
+++ b/src/importexport/datafileparser.cpp
@@ -255,10 +255,7 @@ bool DataFileParser::parseDataLines(QTextStream* pDataStream, QList<QList<double
     {
         QString strippedLine = line.trimmed();
 
-        if (
-            (!strippedLine.isEmpty())
-            && (!isCommentLine(strippedLine))
-        )
+        if (!strippedLine.isEmpty() && !isCommentLine(strippedLine))
         {
             QStringList paramList = strippedLine.split(_pDataParserModel->fieldSeparator());
             const quint32 lineDataCount = static_cast<quint32>(paramList.size() - static_cast<qint32>(_pDataParserModel->column()));

--- a/src/importexport/settingsauto.cpp
+++ b/src/importexport/settingsauto.cpp
@@ -113,7 +113,7 @@ bool SettingsAuto::isAbsoluteDate(QString rawData)
     return match.hasMatch();
 }
 
-bool SettingsAuto::isComment(QString line)
+bool SettingsAuto::determineComment(QString line)
 {
     bool bRet = false;
     if (_commentSequence.isEmpty())
@@ -174,7 +174,7 @@ bool SettingsAuto::testLocale(QStringList previewData, QLocale locale, QString f
         qint32 parseIdx;
         for (parseIdx = _dataRow; parseIdx < previewData.size(); parseIdx++)
         {
-            if (!isComment(previewData[parseIdx]))
+            if (!determineComment(previewData[parseIdx]))
             {
                 QStringList fields = previewData[parseIdx].split(fieldSeparator);
 
@@ -248,12 +248,9 @@ quint32 SettingsAuto::nextDataLine(quint32 startIdx, QStringList previewData, bo
     for (lineIdx = startIdx; lineIdx < previewData.size(); lineIdx++)
     {
         QString line = previewData[lineIdx].trimmed();
-        if (!line.isEmpty())
+        if (!line.isEmpty() && !determineComment(line))
         {
-            if (!isComment(line))
-            {
-                break;
-            }
+            break;
         }
     }
 

--- a/src/importexport/settingsauto.cpp
+++ b/src/importexport/settingsauto.cpp
@@ -113,9 +113,28 @@ bool SettingsAuto::isAbsoluteDate(QString rawData)
     return match.hasMatch();
 }
 
+bool SettingsAuto::isEmptyLine(QString line)
+{
+    if (line.isEmpty())
+    {
+        return true;
+    }
+    if (line.replace(";", "").isEmpty())
+    {
+        return true;
+    }
+    if (line.replace(",", "").isEmpty())
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool SettingsAuto::determineComment(QString line)
 {
     bool bRet = false;
+
     if (_commentSequence.isEmpty())
     {
         // Check first character for comment char
@@ -248,7 +267,7 @@ quint32 SettingsAuto::nextDataLine(quint32 startIdx, QStringList previewData, bo
     for (lineIdx = startIdx; lineIdx < previewData.size(); lineIdx++)
     {
         QString line = previewData[lineIdx].trimmed();
-        if (!line.isEmpty() && !determineComment(line))
+        if (!isEmptyLine(line) && !determineComment(line))
         {
             break;
         }

--- a/src/importexport/settingsauto.h
+++ b/src/importexport/settingsauto.h
@@ -38,6 +38,7 @@ private:
 
     bool isAbsoluteDate(QString rawData);
     bool isModbusScopeDataFile(QString firstLine);
+    bool isEmptyLine(QString line);
     bool determineComment(QString line);
     bool testLocale(QStringList previewData, QLocale locale, QString fieldSeparator);
     quint32 nextDataLine(quint32 startIdx, QStringList previewData, bool *bOk);

--- a/src/importexport/settingsauto.h
+++ b/src/importexport/settingsauto.h
@@ -38,7 +38,7 @@ private:
 
     bool isAbsoluteDate(QString rawData);
     bool isModbusScopeDataFile(QString firstLine);
-    bool isComment(QString line);
+    bool determineComment(QString line);
     bool testLocale(QStringList previewData, QLocale locale, QString fieldSeparator);
     quint32 nextDataLine(quint32 startIdx, QStringList previewData, bool *bOk);
 

--- a/tests/importexport/csvdata.cpp
+++ b/tests/importexport/csvdata.cpp
@@ -189,4 +189,29 @@ QString CsvData::cDatasetMultiAxis = QString(
     "5,0,51000,0"
 );
 
+QString CsvData::cDatasetExcelChanged = QString(
+    "//ModbusScope version;3.5.1;;;;"                                                           "\n"\
+    "//Start time;13-07-2022 12:04:07;;;;"                                                      "\n"\
+    "//End time;13-07-2022 12:04:17;;;;"                                                        "\n"\
+    "//Settings (Connection ID 1);127.0.0.1:502;;;;"                                            "\n"\
+    "//Slave ID (Connection ID 1);1;;;;"                                                        "\n"\
+    "//Time-out (Connection ID 1);1000;;;;"                                                     "\n"\
+    "//Consecutive max (Connection ID 1);125;;;;"                                               "\n"\
+    "//Poll interval;250;;;;"                                                                   "\n"\
+    "//Communication success;28;;;;"                                                            "\n"\
+    "//Communication errors;42;;;;"                                                             "\n"\
+    "//;;;;;"                                                                                   "\n"\
+    "//Property;Register 1;Register 2;Register 3;Register 4;Register 5"                         "\n"\
+    "//Color;#000000;#0000ff;#00ffff;#00ff00;#dcdc00"                                           "\n"\
+    "//Expression;${40001};${40002};${40003};${40004};${40005}"                                 "\n"\
+    "//Axis;0;0;0;0;0"                                                                          "\n"\
+    "//;;;;;"                                                                                   "\n"\
+    ";;;;;"                                                                                     "\n"\
+    "//;;;;;"                                                                                   "\n"\
+    "Time (ms);Register 1;Register 2;Register 3;Register 4;Register 5"                          "\n"\
+    "0;0;4;0;0;0"                                                                             "\n"\
+    "1;0;4;0;0;0"                                                                            "\n"\
+    "2;0;4;0;0;0"                                                                            "\n"\
+);
+
 

--- a/tests/importexport/csvdata.h
+++ b/tests/importexport/csvdata.h
@@ -23,6 +23,7 @@ public:
     static QString cDatasetEmptyLastColumn;
 
     static QString cDatasetMultiAxis;
+    static QString cDatasetExcelChanged;
 
 private:
 

--- a/tests/importexport/tst_settingsauto.cpp
+++ b/tests/importexport/tst_settingsauto.cpp
@@ -208,6 +208,23 @@ void TestSettingsAuto::processDatasetTimeInSeconds()
     QCOMPARE(settingsData.bTimeInMilliSeconds, false);
 }
 
+void TestSettingsAuto::processDatasetExcelChanged()
+{
+    SettingsAuto::settingsData_t settingsData;
+
+    QVERIFY(processFile(&CsvData::cDatasetExcelChanged, &settingsData));
+
+    QCOMPARE(settingsData.bModbusScopeDataFile, true);
+    QCOMPARE(settingsData.fieldSeparator, QChar(';'));
+    QCOMPARE(settingsData.groupSeparator, QChar(' '));
+    QCOMPARE(settingsData.decimalSeparator, QChar(','));
+    QCOMPARE(settingsData.commentSequence, QString("//"));
+    QCOMPARE(settingsData.labelRow, static_cast<quint32>(18));
+    QCOMPARE(settingsData.dataRow, static_cast<quint32>(19));
+    QCOMPARE(settingsData.column, static_cast<quint32>(0));
+    QCOMPARE(settingsData.bTimeInMilliSeconds, true);
+}
+
 
 void TestSettingsAuto::prepareReference(QString* pRefData, QStringList& refList)
 {

--- a/tests/importexport/tst_settingsauto.h
+++ b/tests/importexport/tst_settingsauto.h
@@ -26,6 +26,7 @@ private slots:
 
     void processDatasetAbsoluteDate();
     void processDatasetTimeInSeconds();
+    void processDatasetExcelChanged();
 
 private:
 


### PR DESCRIPTION
Use case:
* Csv exported by ModbusScope
* Opened and edited in Excel
* Opening csv again in ModbusScope

Symptom: Excel added empty columns to all lines to match number of max columns. ModbusScope couldn't handle it.
Root cause: Data export contained empty line.

Both symptom (ignore line with only separators) and root cause (empty line) are fixed.